### PR TITLE
refactor(dep-triage): remove the approval-free merge path

### DIFF
--- a/.agent/skills/dep-triage/SKILL.md
+++ b/.agent/skills/dep-triage/SKILL.md
@@ -14,10 +14,10 @@ Covers two repositories:
 | `vspo-lab/config` | Shared Renovate presets. Validated by `validate-config.yml` |
 
 Handles the dependency updates that automation cannot decide on its own. Grouping
-and cooldown are handled by `renovate.json`; merging is not. Renovate has
-`automerge` disabled everywhere, so this skill is the only automated merger, and it
-merges strictly the classes whose effect on product behavior is nil. Everything
-else it repairs, triages, or hands to a human.
+and cooldown are handled by `renovate.json`. Merging is handled by
+`dep-auto-merge.yaml`, which merges a PR once a human has approved it and the
+checks are green. This skill repairs what is red, triages security findings, and
+reports what is waiting.
 
 # Modes
 
@@ -42,82 +42,29 @@ The invocation states the mode. Default to `report` when it is not given.
 List open PRs labelled `dependencies` with their check status. Classify each as
 green, red, stale-conflicted, or awaiting cooldown.
 
-Renovate never merges anything: `automerge` is off everywhere. This skill is the
-only automated merger, and it merges only what Step 2a proves safe.
+Renovate never merges anything: `automerge` is off everywhere. Merges are performed
+by `dep-auto-merge.yaml`, on approved and green PRs only.
 
 ## Step 2a: Decide what may be merged
 
-**You do not merge.** `.github/workflows/dep-auto-merge.yaml` performs merges, by
-executing the output of `scripts/dep-triage-report.py`. That split exists for a
-concrete reason: a routine session has no GitHub write credentials, while the
-workflow has them natively, and keeping the decision in one reviewable script
-stops the policy from being re-derived by a model on every run.
+**You do not merge.** `.github/workflows/dep-auto-merge.yaml` performs merges by
+executing the output of `scripts/dep-triage-report.py`. Run the evaluator, sanity
+check its decisions, and investigate anything surprising.
 
-Your job at this step is to run the evaluator, confirm its decisions look right,
-and investigate anything surprising. The gates below are what it implements; know
-them so you can tell a correct HOLD from a bug.
+The rule is one line: **a pull request merges when a human with write access has
+approved its current head commit and every required check has passed.**
 
-Two gates, and a PR needs **one of them**, plus green checks in every case.
+- An approval on a superseded commit is stale. The approver never saw what would
+  actually be merged, so it does not count
+- `CHANGES_REQUESTED` blocks the merge regardless of other approvals
+- A check that is absent, pending or skipped is not a pass
 
-### Gate A - a human approved it
-
-An approving review from someone with write access is the human saying "this is
-fine to merge". Take it at face value and merge, whatever the change contains,
-once the checks are green.
-
-- The approval must be on the **current head commit**. If the PR was pushed to
-  after the approval, the approval is stale and Gate A is closed
-- `CHANGES_REQUESTED` from anyone closes Gate A regardless of other approvals
-- An approval is not a licence to merge past a failing check. Green checks are
-  required under both gates
-
-### Gate B - the change cannot affect product behavior
-
-For updates nobody needs to look at. Renovate labels the qualifying classes
-`no-runtime-impact`:
-
-| Class | Why behavior cannot change |
-|-------|------------------------------|
-| `@types/**` | Type declarations are erased at compile time; nothing reaches the bundle |
-| GitHub Actions | CI configuration only, never part of a deployed artifact |
-| Lint, format and docs tooling | Runs in CI only and emits no shipped code |
-| Test tooling | Never imported by production code |
-
-Everything else is out of scope for automated merging, including production
-dependencies at any level, build-chain tooling (`typescript`, `tsup`, `wrangler`,
-`@opennextjs/cloudflare`, Storybook, Vite, Astro), and lockfile-only transitive
-bumps, because each of those can change emitted output.
-
-**The label alone is not sufficient**, for a concrete reason. Renovate applies
-`addLabels` per matching rule, but a label lands on the whole PR. A single PR can
-span more than one manager, so a rule matching one part of it can put
-`no-runtime-impact` on a PR whose other half is not covered by that rule at all.
-
-This has already happened: a pnpm version bump matched the `github-actions` rule
-and arrived labelled `no-runtime-impact`, while also editing
-`.github/actions/setup-pnpm/action.yml`, a deploy workflow, and `package.json`.
-Nothing about that change is free of build impact.
-
-So Gate B opens only when **all** of these hold:
-
-- The `no-runtime-impact` label is present
-- The PR carries neither `major` nor `high-risk`
-- The diff touches only `package.json`, `pnpm-lock.yaml` and `pnpm-workspace.yaml`.
-  Anything under `.github/`, any source file, any config file closes the gate
-
-Check the diff yourself; do not take the label's word for it.
-
-### Required under both gates
-
-- Every required check has run and passed. A check that is absent, pending or
-  skipped is not a pass
-- Under Gate B only: the diff restrictions above hold, and `bundle-size` reports
-  no delta for anything that could reach the bundle
-
-`scripts/dep-triage-report.py` evaluates both gates against the live API and
-prints the decision per PR. Run it rather than judging by eye, and treat its
-output as the answer. It exists so the gates are machine-checked instead of
-re-derived from prose on every run.
+There is deliberately no second path. An earlier design added one for changes
+whose class "cannot affect the product", and it cost more than it was worth: it
+collided with `CODEOWNERS`, collided again with the branch protection approval
+requirement, and admitted a PR that edited deploy workflows because Renovate
+applies labels per rule while the label lands on the whole PR. Approving is
+cheap; a second gate that merges without anyone looking was not.
 
 If a check fails identically on the base branch, that is a base-branch defect.
 Escalate it; it is not a licence to merge past a red check.
@@ -228,9 +175,8 @@ Allowed:
 Never:
 
 - Merge any pull request. That is the workflow's job, not yours
-- Add the `no-runtime-impact` label to a PR, or remove `major` or `high-risk`
-  from one. Editing labels to change a gate's outcome is out of bounds
-- Approve a pull request. Gate A must be opened by a human
+- Approve a pull request, or ask someone to approve one. The approval is the
+  whole gate, and it has to come from a human who chose to give it
 - Edit `scripts/dep-triage-report.py` to make a specific PR mergeable. Change it
   only to fix a policy defect, in its own PR, explaining the defect
 - Merge a PR labelled `major` or `high-risk`

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,21 +1,2 @@
 # CODEOWNERS docs: https://docs.github.com/ja/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 *                    @sugar-cat7
-
-# Dependency manifests have no code owner.
-#
-# dep-auto-merge only ever merges a PR whose diff is confined to these files
-# (Gate B), and it was refused with:
-#
-#   gh: Waiting on code owner review from sugar-cat7. (HTTP 405)
-#
-# Requiring a code-owner review on a lockfile bump blocks the automation without
-# adding review value: the gates already require every check green plus either a
-# human approval or a change class that cannot affect the product.
-#
-# CODEOWNERS is last-match-wins and an empty owner list removes ownership, so
-# these three lines must stay below the `*` rule above. `!` negation is not
-# supported here. No leading slash, so they match in every workspace package too,
-# matching how the evaluator classifies a manifest-only diff.
-package.json
-pnpm-lock.yaml
-pnpm-workspace.yaml

--- a/.github/workflows/dep-auto-merge.yaml
+++ b/.github/workflows/dep-auto-merge.yaml
@@ -1,18 +1,19 @@
 name: Dependency Auto Merge
 
-# Merges dependency PRs that satisfy the dep-triage gates. This workflow makes no
-# decisions of its own: scripts/dep-triage-report.py evaluates the gates and this
-# job executes the result, so the policy stays reviewable in one place.
+# Merges a pull request once a human has approved it and every check is green.
+# This workflow makes no decisions of its own: scripts/dep-triage-report.py
+# decides and this job executes the result, so the policy stays reviewable in one
+# place.
 #
 # Renovate's own automerge is disabled, because it merges on "CI green" alone.
-# The gates here are strictly stronger: green checks AND either a human approval
-# on the current head commit, or a change whose class cannot affect the product.
+# An approval is the part that makes a merge deliberate.
 
 on:
-  # A review is the usual way Gate A opens, so react to it immediately.
+  # The usual path: approve, and the merge follows within the minute.
   pull_request_review:
     types: [submitted]
-  # Gate B PRs open when their checks finish, which no review event covers.
+  # Covers approving a PR whose checks are still running. No further review event
+  # fires when they finish, so without this the PR would wait for the next push.
   schedule:
     - cron: '15 * * * *'
   workflow_dispatch:
@@ -37,7 +38,7 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
 
-      - name: Evaluate the merge gates
+      - name: Decide what may be merged
         id: evaluate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -46,7 +47,7 @@ jobs:
           python3 scripts/dep-triage-report.py --json vspo-lab/vspo-portal > /tmp/decisions.json
           python3 scripts/dep-triage-report.py vspo-lab/vspo-portal
 
-      - name: Merge everything the evaluator approved
+      - name: Merge what the evaluator cleared
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -54,7 +55,7 @@ jobs:
 
           COUNT=$(python3 -c "import json;print(sum(1 for d in json.load(open('/tmp/decisions.json')) if d['decision']=='MERGE'))")
           if [ "$COUNT" -eq 0 ]; then
-            echo "Nothing satisfies the gates. This is a normal outcome."
+            echo "Nothing is approved and green. This is a normal outcome."
             exit 0
           fi
 

--- a/docs/infra/ci-cd.md
+++ b/docs/infra/ci-cd.md
@@ -308,7 +308,7 @@ packages:
 
 Managed via automatic updates with Renovate or Dependabot.
 
-Renovate is the single source of dependency updates; Dependabot security updates are disabled to avoid duplicate PRs for the same advisory. `renovate.json` groups updates and inherits the shared preset's 7-day supply-chain cooldown. Renovate itself never merges: the `dep-triage` routine is the only automated merger, and it merges only changes labelled `no-runtime-impact` whose checks are fully green. See [Dependency Auto Flow](./dependency-auto-flow.md) for the full design and [Dependency Security Policy](../security/dependency-policy.md) for the policy.
+Renovate is the single source of dependency updates; Dependabot security updates are disabled to avoid duplicate PRs for the same advisory. `renovate.json` groups updates and inherits the shared preset's 7-day supply-chain cooldown. Renovate itself never merges: `dep-auto-merge.yaml` merges a PR once a human has approved its current head commit and every check is green. See [Dependency Auto Flow](./dependency-auto-flow.md) for the full design and [Dependency Security Policy](../security/dependency-policy.md) for the policy.
 
 ---
 

--- a/docs/infra/dependency-auto-flow.md
+++ b/docs/infra/dependency-auto-flow.md
@@ -48,23 +48,19 @@ transitive `pnpm.overrides` pins.
 | `osvVulnerabilityAlerts` | `true` | Advisory source, replacing Dependabot |
 | `lockFileMaintenance` | weekly | Keeps transitive dependencies fresh; merged like any other PR |
 
-### Grouping and merge eligibility
+### Grouping
 
-Renovate has `automerge` disabled everywhere and never merges. Grouping exists to
-batch PRs, and the `no-runtime-impact` label marks the only classes the routine is
-permitted to merge.
+Renovate has `automerge` disabled everywhere and never merges. Grouping exists
+only to keep the PR count down.
 
-| Group | Matches | `no-runtime-impact` |
-|-------|---------|---------------------|
-| `type-definitions` | `@types/**`, patch + minor | Yes |
-| `github-actions` | github-actions manager, patch + minor + digest | Yes |
-| `lint-tooling` | Biome, cspell, knip, textlint, markdownlint, lefthook | Yes |
-| `test-tooling` | Vitest, Testing Library, jsdom | Yes |
-| `build-tooling` | TypeScript, tsup, turbo, Storybook, Vite, Tailwind, Wrangler, OpenNext, Astro | No, changes emitted output |
-| `dev-dependencies` | remaining devDependencies, patch + minor | No |
-| `production-patch` / `production-minor` | dependencies | No, runtime behavior can change |
-| high-risk | `next`, `react`, `react-dom`, `wrangler`, `@opennextjs/cloudflare`, `@cloudflare/workers-types`, `typescript`, `@biomejs/biome`, `astro` | No, ungrouped |
-| major | any major | No, requires dashboard approval |
+| Group | Matches |
+|-------|---------|
+| `type-definitions` | `@types/**`, patch + minor |
+| `github-actions` | github-actions manager, patch + minor + digest |
+| `dev-dependencies` | all devDependencies below major |
+| `production-patch` / `production-minor` | dependencies |
+| high-risk | `next`, `react`, `react-dom`, `wrangler`, `@opennextjs/cloudflare`, `@cloudflare/workers-types`, `typescript`, `@biomejs/biome`, `astro`. Ungrouped and labelled, so they are obvious when deciding whether to approve |
+| major | any major. Requires dashboard approval |
 
 `vulnerabilityAlerts` overrides the cooldown with `minimumReleaseAge: null`, so a
 fix for a known CVE is never delayed.
@@ -73,53 +69,40 @@ fix for a known CVE is never delayed.
 
 ### Merge criterion
 
+A pull request merges when a human with write access has approved its current head
+commit and every required check has passed. That is the whole rule.
+
 Merging is performed by `.github/workflows/dep-auto-merge.yaml`, never by Renovate
 and never by GitHub auto-merge. The workflow decides nothing: it runs
-`scripts/dep-triage-report.py` and executes the result.
+`scripts/dep-triage-report.py` and executes the result, so the policy lives in one
+reviewable place instead of being re-derived from prose on every run.
 
-Renovate's automerge was rejected because it merges on "CI green" alone. These
-gates are strictly stronger, so that concern is met without giving Renovate the
-merge button.
+Renovate's own automerge is disabled because it merges on "CI green" alone. The
+approval is what makes a merge deliberate.
 
-The workflow holds the credentials; the routine holds the judgement. A routine
-session has no GitHub write access, so putting the merge there would have meant
-inventing a way to grant it. Keeping the decision in one script also means the
-policy is reviewed as code rather than reconstructed from prose each morning.
+- An approval on a superseded commit is stale: the approver never saw what would
+  actually be merged
+- `CHANGES_REQUESTED` blocks the merge regardless of other approvals
+- A check that is absent, pending or skipped is not a pass
 
-Every required check must be green, and one of two gates must be open:
+#### Why there is no approval-free path
 
-| Gate | Condition | Covers |
-|------|-----------|--------|
-| A | A human with write access approved the current head commit | Anything. The approval is the human's judgement, taken at face value |
-| B | The PR carries `no-runtime-impact`, carries neither `major` nor `high-risk`, and the diff touches only `package.json`, `pnpm-lock.yaml` and `pnpm-workspace.yaml` | Updates nobody needs to look at |
+An earlier design had a second gate that merged changes whose class "cannot affect
+the product" — type definitions, CI tooling — without anyone approving. It was
+removed, because it cost more than it saved:
 
-An approval on a superseded commit is stale and does not open Gate A, and a
-`CHANGES_REQUESTED` review closes it. Neither gate permits merging past a failing,
-pending or absent check.
+- It required a `CODEOWNERS` carve-out, since a repository-wide code owner blocks
+  any merge the owner has not reviewed
+- It then hit the branch protection approval requirement anyway, which the human
+  maintainer routinely bypasses as an admin but a bot cannot
+- It admitted a PR that edited `.github/actions/setup-pnpm/action.yml` and a deploy
+  workflow, because Renovate applies `addLabels` per matching rule while the label
+  lands on the whole PR
 
-Opening a gate is necessary but not sufficient: GitHub still applies branch
-protection. `CODEOWNERS` originally assigned every file to a single owner, so the
-first Gate B merge was refused with `Waiting on code owner review` even though the
-gate was open and all seventeen checks were green. The dependency manifests
-therefore carry no code owner, which is exactly the set Gate B is allowed to touch.
+Approving a dependency PR is cheap. A path that merges without anyone looking was
+not, and every incident above came from it.
 
-Gate B never trusts the label on its own. Renovate applies `addLabels` per matching
-rule but the label lands on the whole PR, so a PR spanning two managers can arrive
-labelled from a rule that covers only half of it. A pnpm bump did exactly that: it
-matched the `github-actions` rule, arrived `no-runtime-impact`, and also edited
-`.github/actions/setup-pnpm/action.yml`, a deploy workflow and `package.json`. The
-label check, the `major`/`high-risk` exclusion and the diff check are three
-independent conditions for that reason.
-
-`scripts/dep-triage-report.py` evaluates the gates against the live API and prints
-a decision per PR, so the policy is machine-checked rather than re-derived by hand.
-
-Gate B exists so routine noise (type definitions, CI tooling) never reaches a
-human. Everything else, production dependencies and build-chain tooling included,
-waits for an approval. A green check suite alone is not sufficient, because a
-green suite does not prove that emitted output is unchanged.
-
-For that criterion to mean anything, the checks must actually run. `pr-check.yaml`
+For the criterion to mean anything, the checks must actually run. `pr-check.yaml`
 therefore triggers on the root `package.json`, `pnpm-lock.yaml` and
 `pnpm-workspace.yaml`, and carries a `deps` path filter that pulls in the `knip`,
 `bundle-size` and `test` jobs. Without it, a lockfile-only PR would run no jobs at
@@ -134,7 +117,7 @@ checks red with an error that names none of them.
 Renovate produced exactly that on #1125: `package.json` moved
 `markdownlint-cli2` to `^0.23.0` with no lockfile change, `CI=true` made the
 install frozen, and the PR sat unmergeable for twelve days. It was the only PR
-that had ever opened Gate B, so the whole flow had nothing to merge.
+eligible to merge at the time, so the whole flow had nothing to act on.
 
 The workflow runs frozen install and judges by exit code. On `renovate/**` and
 `dependabot/**` it regenerates the lockfile and pushes; anywhere else it fails
@@ -170,7 +153,7 @@ manually.
 ### Auto merge (`dep-auto-merge.yaml`)
 
 Runs on `pull_request_review` (so an approval acts within the minute), hourly on a
-schedule (so Gate B PRs merge once their checks land), and on demand. It checks out
+schedule (so a PR approved while its checks were still running still merges), and on demand. It checks out
 the default branch rather than the PR's version of the script, so a pull request
 cannot rewrite the policy that admits it.
 

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -10,9 +10,9 @@ over time.
 |-------|------|
 | Update bot | Renovate only. Dependabot security updates are disabled; advisories arrive through `osvVulnerabilityAlerts` |
 | Cooldown | 7 days for npm packages, inherited from the shared preset; none for known-CVE fixes |
-| Merge criterion | Every required check green, plus either a human approval on the current head commit, or the `no-runtime-impact` label |
-| Who may merge | The `dep-triage` routine only. Renovate automerge is disabled everywhere |
-| Merge without review | Only `no-runtime-impact` classes: `@types/*`, GitHub Actions, lint tooling, test tooling |
+| Merge criterion | A human approval on the current head commit, plus every required check green |
+| Who may merge | `dep-auto-merge.yaml` only. Renovate automerge is disabled everywhere |
+| Merge without review | Never. There is no approval-free path |
 | Merge with review | Anything, once approved by a human with write access |
 | Blocking scan | Trivy, production dependencies only, CRITICAL and HIGH |
 | Non-blocking scan | Trivy with `--include-dev-deps`, report only |

--- a/renovate.json
+++ b/renovate.json
@@ -24,70 +24,19 @@
   },
   "packageRules": [
     {
-      "description": "Type definitions: erased at compile time, so a passing tsc proves no runtime change",
+      "description": "Type definitions: grouped to keep the PR count down",
       "matchPackageNames": ["@types/**"],
       "matchUpdateTypes": ["patch", "minor"],
-      "groupName": "type-definitions",
-      "addLabels": ["no-runtime-impact"]
+      "groupName": "type-definitions"
     },
     {
-      "description": "GitHub Actions: CI only, never part of a deployed artifact",
+      "description": "GitHub Actions: grouped to keep the PR count down",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["patch", "minor", "digest"],
-      "groupName": "github-actions",
-      "addLabels": ["no-runtime-impact"]
+      "groupName": "github-actions"
     },
     {
-      "description": "Lint, format and docs tooling: runs in CI only, emits no shipped code",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "matchPackageNames": [
-        "@biomejs/biome",
-        "cspell",
-        "knip",
-        "markdownlint-cli2",
-        "textlint",
-        "textlint-**",
-        "@textlint/**",
-        "lefthook"
-      ],
-      "groupName": "lint-tooling",
-      "addLabels": ["no-runtime-impact"]
-    },
-    {
-      "description": "Test tooling: never imported by production code",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "matchPackageNames": [
-        "vitest",
-        "@vitest/**",
-        "@testing-library/**",
-        "jsdom",
-        "happy-dom"
-      ],
-      "groupName": "test-tooling",
-      "addLabels": ["no-runtime-impact"]
-    },
-    {
-      "description": "Build-chain devDependencies: change emitted output, so impact is not provable from CI alone",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "matchPackageNames": [
-        "tsup",
-        "turbo",
-        "typescript",
-        "storybook",
-        "@storybook/**",
-        "@vitejs/**",
-        "@tailwindcss/**",
-        "wrangler",
-        "@opennextjs/cloudflare",
-        "@astrojs/**"
-      ],
-      "groupName": "build-tooling"
-    },
-    {
-      "description": "Remaining devDependencies",
+      "description": "All devDependencies below major, in one PR",
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "dev-dependencies"

--- a/scripts/dep-triage-report.py
+++ b/scripts/dep-triage-report.py
@@ -1,20 +1,18 @@
 #!/usr/bin/env python3
-"""Evaluate the dep-triage merge gates against open pull requests.
+"""Decide which open pull requests may be merged automatically.
+
+A pull request qualifies when a human with write access has approved its current
+head commit and every required check has passed. Nothing else qualifies.
 
 Preconditions:
     - The repository is public, or GITHUB_TOKEN is set in the environment.
       Reads only; nothing is written to GitHub.
 Postconditions:
-    - Prints one block per open pull request with the gate evaluation and the
-      resulting decision, then a one-line verdict. Exit 0 when every PR was
-      evaluated, 1 when any API call failed.
+    - Prints one block per open pull request with the decision and its reason,
+      then a one-line verdict. Exit 0 when every PR was evaluated, 1 when any
+      API call failed.
 Idempotency:
     - Pure read. Running it twice against unchanged state prints the same thing.
-
-Why this exists: the merge gates are policy, and policy re-derived from prose on
-every run drifts. This makes the decision reproducible and reviewable, and it is
-the mechanism that caught `no-runtime-impact` leaking onto a PR that also edited
-workflow files.
 
 This script never writes to GitHub. It only decides. Acting on its decisions is
 the caller's job: `.github/workflows/dep-auto-merge.yaml` consumes `--json` and
@@ -34,14 +32,6 @@ import urllib.request
 
 DEFAULT_REPOS = ["vspo-lab/vspo-portal", "vspo-lab/config"]
 
-NO_IMPACT = "no-runtime-impact"
-BLOCKING_LABELS = ("major", "high-risk")
-
-# Gate B requires the diff to stay inside the dependency manifests. Anything
-# under .github/, any source file and any config file closes the gate, because
-# those can change what is built or how it is built.
-GATE_B_PATHS = ("package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml")
-
 # A check in one of these states has produced no evidence, so it is not a pass.
 PASSING_CONCLUSIONS = ("success", "skipped", "neutral")
 
@@ -57,16 +47,13 @@ def api(repo: str, path: str):
 
 
 def evaluate(repo: str, pr: dict) -> dict:
-    """Apply both merge gates to a single pull request."""
+    """Decide whether one pull request may be merged."""
     number = pr["number"]
     head = pr["head"]["sha"]
-    labels = [label["name"] for label in pr["labels"]]
-
-    files = [f["filename"] for f in api(repo, f"/pulls/{number}/files?per_page=100")]
-    manifest_only = bool(files) and all(f.endswith(GATE_B_PATHS) for f in files)
 
     reviews = api(repo, f"/pulls/{number}/reviews?per_page=100")
-    # An approval on a superseded commit is stale and does not count.
+    # An approval on a superseded commit is stale: the approver never saw what
+    # would actually be merged.
     approvals = [
         r for r in reviews if r["state"] == "APPROVED" and r.get("commit_id") == head
     ]
@@ -81,10 +68,6 @@ def evaluate(repo: str, pr: dict) -> dict:
     ]
     green = bool(runs) and not pending and not failed
 
-    blocked_by = [label for label in labels if label in BLOCKING_LABELS]
-    gate_a = bool(approvals) and not changes_requested
-    gate_b = NO_IMPACT in labels and not blocked_by and manifest_only
-
     if not green:
         detail = []
         if failed:
@@ -94,28 +77,25 @@ def evaluate(repo: str, pr: dict) -> dict:
         if not runs:
             detail.append("no checks ran at all")
         decision, why = "HOLD", "checks not green (" + "; ".join(detail) + ")"
-    elif gate_a:
-        decision, why = "MERGE", "Gate A: approved on the current head commit"
-    elif gate_b:
-        decision, why = "MERGE", "Gate B: no-runtime-impact, manifests only"
-    elif NO_IMPACT not in labels:
-        decision, why = "HOLD", "no gate open: not approved, and not labelled no-runtime-impact"
-    elif blocked_by:
-        decision, why = "HOLD", f"labelled {NO_IMPACT} but also {'/'.join(blocked_by)}"
+    elif changes_requested:
+        decision, why = "HOLD", "changes requested"
+    elif approvals:
+        approver = approvals[0]["user"]["login"]
+        decision, why = "MERGE", f"approved by {approver} on the current head commit"
     else:
-        outside = [f for f in files if not f.endswith(GATE_B_PATHS)]
-        decision, why = "HOLD", f"labelled {NO_IMPACT} but the diff touches {', '.join(outside[:3])}"
+        stale = [r for r in reviews if r["state"] == "APPROVED"]
+        why = "not approved"
+        if stale:
+            why = "the only approval is on a superseded commit"
+        decision = "HOLD"
 
     return {
         "repo": repo,
         "number": number,
         "title": pr["title"],
         "base": pr["base"]["ref"],
-        "labels": labels,
-        "files": files,
+        "labels": [label["name"] for label in pr["labels"]],
         "checks": (len(runs), len(failed), len(pending)),
-        "gate_a": gate_a,
-        "gate_b": gate_b,
         "decision": decision,
         "why": why,
     }
@@ -156,9 +136,7 @@ def main() -> int:
         print(f"{r['repo']}#{r['number']}  base={r['base']}")
         print(f"    {r['title'][:78]}")
         print(f"    labels : {', '.join(r['labels']) or '-'}")
-        print(f"    files  : {len(r['files'])} ({'manifests only' if all(f.endswith(GATE_B_PATHS) for f in r['files']) else 'touches more than manifests'})")
         print(f"    checks : {total} total, {failed} failed, {pending} pending")
-        print(f"    gates  : A={r['gate_a']}  B={r['gate_b']}")
         print(f"    => {r['decision']}: {r['why']}")
         # Reaching main directly skips develop, and merging there deploys.
         if r["base"] == "main" and r["repo"].endswith("vspo-portal"):


### PR DESCRIPTION
## Current State

The requirement was always simple: **approve a Renovate PR and it merges, assuming CI is green.**

I added a second gate on top of that — merging changes whose class "cannot affect the product" without anyone approving. Every problem since traces back to it.

## Problem

Three incidents, one cause:

1. **It needed a `CODEOWNERS` carve-out.** A repository-wide code owner blocks any merge the owner has not reviewed, so `#1127` removed ownership from the dependency manifests.
2. **It then hit the branch protection approval requirement anyway.** That requirement is bypassed routinely by the maintainer as an admin, but a bot cannot bypass it. Two settings had to be weakened to admit a path nobody had asked for.
3. **It admitted `#1122`**, which edited `.github/actions/setup-pnpm/action.yml` and a deploy workflow, because Renovate applies `addLabels` per matching rule while the label lands on the whole PR. Only the diff check stopped it, and that was luck rather than design.

Approving a dependency PR is cheap. A path that merges without anyone looking was not.

## Changes

The rule is now one line: **a PR merges when a human with write access has approved its current head commit and every required check has passed.**

| File | Change |
|---|---|
| `scripts/dep-triage-report.py` | Drops the label, blocking-label and manifest-path logic. The `MERGE` reason now names the approver |
| `renovate.json` | Drops the `no-runtime-impact` labels. The lint / test / build tooling split existed only to drive them, so it collapses back into `dev-dependencies` — which also means fewer PRs. `major` and `high-risk` labels stay, since they are useful when deciding whether to approve |
| `.github/CODEOWNERS` | Returns to covering everything. The carve-out is unnecessary once the owner is the approver |
| `dep-auto-merge.yaml` | Comments and step names reflect the single rule |
| Skill and docs | State the rule, and record why the second gate was removed so it does not get reinvented |

Net **−162 lines**.

### Deliberately kept

- **`lockfile-sync`** — unrelated to any gate, and it cleared a twelve-day blockage. Untouched.
- **The hourly schedule** — covers approving a PR whose checks are still running. No further review event fires when they finish, so without it that PR would wait for the next push.
- **Renovate automerge stays off** — it merges on "CI green" alone, which is the thing the approval is there to prevent.

## Impact

No production impact: policy, configuration and documentation only.

Verified:

- `biome`, `knip`, `tsc`, `cspell`, `markdownlint`, `textlint` all pass
- `renovate-config-validator` passes against `renovate@latest`
- The workflow YAML parses, and the evaluator runs clean against both repositories

### One thing worth knowing

**The approve-then-merge path has still never actually fired.** I said earlier that #1125 proved it worked; that was wrong. Checking the API, #1125 had **zero reviews** and was merged by hand:

```text
merged_by  : sugar-cat7
review count: 0
```

So it was an admin merge, not an approval-triggered one. The next Renovate PR you approve rather than merge will be the first real test — expect it to merge within a minute of the approval.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCUZqautYkM7pLZHCZ6obn)_