### PR TITLE
Add watch link button to VideoCard component

### DIFF
--- a/service/vspo-schedule/v2/web/.storybook/main.ts
+++ b/service/vspo-schedule/v2/web/.storybook/main.ts
@@ -2,6 +2,7 @@ import type { StorybookConfig } from "@storybook/nextjs";
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.@(ts|tsx)"],
+  staticDirs: ["../public"],
   framework: {
     name: "@storybook/nextjs",
     options: {},

--- a/service/vspo-schedule/v2/web/.storybook/preview.tsx
+++ b/service/vspo-schedule/v2/web/.storybook/preview.tsx
@@ -1,29 +1,19 @@
 import type { Preview } from "@storybook/react";
 import { NextIntlClientProvider } from "next-intl";
+import common from "../public/locales/ja/common.json";
+import schedule from "../public/locales/ja/schedule.json";
+import streams from "../public/locales/ja/streams.json";
 import { ThemeModeProvider } from "../src/context/Theme";
+import { VideoModalContext } from "../src/context/VideoModalContext";
 
-const messages = {
-  streams: {
-    status: {
-      live: "配信中",
-      upcoming: "配信予定",
-    },
-    events: "イベント",
-  },
-  schedule: {
-    tabs: {
-      all: "すべて",
-      allWithDate: "すべて ({{date}}~)",
-    },
-    navigation: {
-      previousDay: "前日",
-      nextDay: "翌日",
-    },
-    noLivestreams: "配信はありません",
-    search: {
-      dateSearch: "日付検索",
-    },
-  },
+const messages = { common, schedule, streams };
+
+// Stories render cards in isolation, so the modal itself is not mounted.
+const videoModalContextValue = {
+  activeVideo: undefined,
+  pushVideo: () => {},
+  popVideo: () => {},
+  clearVideos: () => {},
 };
 
 const preview: Preview = {
@@ -31,7 +21,9 @@ const preview: Preview = {
     (Story) => (
       <NextIntlClientProvider locale="ja" messages={messages}>
         <ThemeModeProvider>
-          <Story />
+          <VideoModalContext.Provider value={videoModalContextValue}>
+            <Story />
+          </VideoModalContext.Provider>
         </ThemeModeProvider>
       </NextIntlClientProvider>
     ),

--- a/service/vspo-schedule/v2/web/public/locales/cn/common.json
+++ b/service/vspo-schedule/v2/web/public/locales/cn/common.json
@@ -58,6 +58,16 @@
     "watch": "观看",
     "share": "分享"
   },
+  "videoCard": {
+    "watch": "观看",
+    "watchOn": {
+      "youtube": "在 YouTube 上观看",
+      "twitch": "在 Twitch 上观看",
+      "twitcasting": "在 TwitCasting 上观看",
+      "niconico": "在 Niconico 上观看",
+      "unknown": "打开视频页面"
+    }
+  },
   "relatedVideos": {
     "dataLoadError": "数据加载失败。",
     "loadMore": "加载更多"

--- a/service/vspo-schedule/v2/web/public/locales/en/common.json
+++ b/service/vspo-schedule/v2/web/public/locales/en/common.json
@@ -57,6 +57,16 @@
     "watch": "Watch",
     "share": "Share"
   },
+  "videoCard": {
+    "watch": "Watch",
+    "watchOn": {
+      "youtube": "Watch on YouTube",
+      "twitch": "Watch on Twitch",
+      "twitcasting": "Watch on TwitCasting",
+      "niconico": "Watch on Niconico",
+      "unknown": "Open the video page"
+    }
+  },
   "relatedVideos": {
     "dataLoadError": "Error loading data.",
     "loadMore": "More videos"

--- a/service/vspo-schedule/v2/web/public/locales/ja/common.json
+++ b/service/vspo-schedule/v2/web/public/locales/ja/common.json
@@ -55,6 +55,16 @@
     "watch": "視聴",
     "share": "共有"
   },
+  "videoCard": {
+    "watch": "視聴",
+    "watchOn": {
+      "youtube": "YouTubeで視聴",
+      "twitch": "Twitchで視聴",
+      "twitcasting": "ツイキャスで視聴",
+      "niconico": "ニコニコで視聴",
+      "unknown": "配信ページを開く"
+    }
+  },
   "relatedVideos": {
     "dataLoadError": "データの取得に失敗しました。",
     "loadMore": "もっと見る"

--- a/service/vspo-schedule/v2/web/public/locales/ko/common.json
+++ b/service/vspo-schedule/v2/web/public/locales/ko/common.json
@@ -58,6 +58,16 @@
     "watch": "시청",
     "share": "공유"
   },
+  "videoCard": {
+    "watch": "시청",
+    "watchOn": {
+      "youtube": "YouTube에서 시청",
+      "twitch": "Twitch에서 시청",
+      "twitcasting": "트윗캐스팅에서 시청",
+      "niconico": "니코니코에서 시청",
+      "unknown": "영상 페이지 열기"
+    }
+  },
   "relatedVideos": {
     "dataLoadError": "데이터 로드 오류.",
     "loadMore": "더 많은 영상"

--- a/service/vspo-schedule/v2/web/public/locales/tw/common.json
+++ b/service/vspo-schedule/v2/web/public/locales/tw/common.json
@@ -58,6 +58,16 @@
     "watch": "觀看",
     "share": "分享"
   },
+  "videoCard": {
+    "watch": "觀看",
+    "watchOn": {
+      "youtube": "在 YouTube 上觀看",
+      "twitch": "在 Twitch 上觀看",
+      "twitcasting": "在 TwitCasting 上觀看",
+      "niconico": "在 Niconico 上觀看",
+      "unknown": "開啟影片頁面"
+    }
+  },
   "relatedVideos": {
     "dataLoadError": "數據加載失敗。",
     "loadMore": "查看更多"

--- a/service/vspo-schedule/v2/web/src/features/schedule/pages/ScheduleStatus/components/LivestreamContent/LivestreamCard.stories.tsx
+++ b/service/vspo-schedule/v2/web/src/features/schedule/pages/ScheduleStatus/components/LivestreamContent/LivestreamCard.stories.tsx
@@ -2,17 +2,21 @@ import type { Meta, StoryObj } from "@storybook/react";
 import type { Livestream } from "@/features/shared/domain/livestream";
 import { LivestreamCard } from "./LivestreamCard";
 
+// Inline so stories render without any network access.
+const sampleThumbnail =
+  "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0ODAiIGhlaWdodD0iMjcwIiB2aWV3Qm94PSIwIDAgNDgwIDI3MCI+CiAgPGRlZnM+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImciIHgxPSIwIiB5MT0iMCIgeDI9IjEiIHkyPSIxIj4KICAgICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzViNGI4YSIvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiMyYjZjYTMiLz4KICAgIDwvbGluZWFyR3JhZGllbnQ+CiAgPC9kZWZzPgogIDxyZWN0IHdpZHRoPSI0ODAiIGhlaWdodD0iMjcwIiBmaWxsPSJ1cmwoI2cpIi8+CiAgPGNpcmNsZSBjeD0iMzYwIiBjeT0iNzAiIHI9IjkwIiBmaWxsPSIjZmZmZmZmIiBvcGFjaXR5PSIwLjA4Ii8+CiAgPGNpcmNsZSBjeD0iOTAiIGN5PSIyMjAiIHI9IjcwIiBmaWxsPSIjZmZmZmZmIiBvcGFjaXR5PSIwLjA4Ii8+CiAgPHRleHQgeD0iMjQwIiB5PSIxNDAiIGZvbnQtZmFtaWx5PSJzYW5zLXNlcmlmIiBmb250LXNpemU9IjM0IiBmb250LXdlaWdodD0iNzAwIiBmaWxsPSIjZmZmZmZmIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIj5TQU1QTEU8L3RleHQ+CiAgPHRleHQgeD0iMjQwIiB5PSIxODAiIGZvbnQtZmFtaWx5PSJzYW5zLXNlcmlmIiBmb250LXNpemU9IjIwIiBmaWxsPSIjZmZmZmZmIiBvcGFjaXR5PSIwLjg1IiB0ZXh0LWFuY2hvcj0ibWlkZGxlIj50aHVtYm5haWwgMTY6OTwvdGV4dD4KPC9zdmc+Cg==";
+
 const baseLivestream: Livestream = {
   id: "ls-1",
   type: "livestream",
   title: "APEX Legends Ranked",
   description: "",
   platform: "youtube",
-  thumbnailUrl: "https://via.placeholder.com/480x270",
+  thumbnailUrl: sampleThumbnail,
   viewCount: 1500,
   channelId: "ch-1",
   channelTitle: "Test Channel",
-  channelThumbnailUrl: "https://via.placeholder.com/36",
+  channelThumbnailUrl: "/icon-top.png",
   link: "https://example.com",
   tags: [],
   status: "live",
@@ -58,8 +62,8 @@ export const WithAdditionalMembers: Story = {
     isFreechat: false,
     timeZone: "Asia/Tokyo",
     additionalMembers: [
-      { name: "Member A", iconUrl: "https://via.placeholder.com/36" },
-      { name: "Member B", iconUrl: "https://via.placeholder.com/36" },
+      { name: "Member A", iconUrl: "/icon-top.png" },
+      { name: "Member B", iconUrl: "/icon-top.png" },
     ],
   },
 };

--- a/service/vspo-schedule/v2/web/src/features/shared/components/Elements/Card/VideoCard.test.tsx
+++ b/service/vspo-schedule/v2/web/src/features/shared/components/Elements/Card/VideoCard.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ThemeModeProvider } from "@/context/Theme";
+import type { Video } from "@/features/shared/domain/video";
+import { VideoCard } from "./VideoCard";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const mockPushVideo = vi.fn();
+vi.mock("@/hooks", () => ({
+  useVideoModalContext: () => ({ pushVideo: mockPushVideo }),
+}));
+
+const makeVideo = (overrides: Partial<Video> = {}): Video => ({
+  id: "v-1",
+  type: "livestream",
+  title: "Test Stream",
+  description: "",
+  platform: "youtube",
+  thumbnailUrl: "https://example.com/thumb.jpg",
+  viewCount: 0,
+  channelId: "ch-1",
+  channelTitle: "Test Channel",
+  channelThumbnailUrl: "https://example.com/icon.jpg",
+  link: "https://www.youtube.com/watch?v=abc123",
+  tags: [],
+  ...overrides,
+});
+
+const renderCard = (video: Video) =>
+  render(
+    <ThemeModeProvider>
+      <VideoCard video={video}>
+        <div>card body</div>
+      </VideoCard>
+    </ThemeModeProvider>,
+  );
+
+const getWatchLink = (platform = "youtube") =>
+  screen.getByRole("link", { name: `videoCard.watchOn.${platform}` });
+
+describe("VideoCard", () => {
+  it("renders a watch link pointing at the source platform in a new tab", () => {
+    renderCard(makeVideo());
+
+    const link = getWatchLink();
+    expect(link).toHaveAttribute(
+      "href",
+      "https://www.youtube.com/watch?v=abc123",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("labels the watch link with the platform of the video", () => {
+    renderCard(makeVideo({ platform: "twitch" }));
+
+    expect(getWatchLink("twitch")).toBeInTheDocument();
+  });
+
+  it("shows the watch label on the button", () => {
+    renderCard(makeVideo());
+
+    expect(getWatchLink()).toHaveTextContent("videoCard.watch");
+  });
+
+  it("falls back to a generic label for an unknown platform", () => {
+    renderCard(makeVideo({ platform: "unknown" }));
+
+    expect(getWatchLink("unknown")).toBeInTheDocument();
+  });
+
+  it("does not open the detail modal when the watch link is clicked", () => {
+    renderCard(makeVideo());
+
+    fireEvent.click(getWatchLink());
+
+    expect(mockPushVideo).not.toHaveBeenCalled();
+  });
+
+  it("opens the detail modal when the card body is clicked", () => {
+    const video = makeVideo();
+    renderCard(video);
+
+    fireEvent.click(screen.getByText("card body"));
+
+    expect(mockPushVideo).toHaveBeenCalledWith(video);
+  });
+
+  it("omits the watch link when the video has no link", () => {
+    renderCard(makeVideo({ link: "" }));
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/service/vspo-schedule/v2/web/src/features/shared/components/Elements/Card/VideoCard.test.tsx
+++ b/service/vspo-schedule/v2/web/src/features/shared/components/Elements/Card/VideoCard.test.tsx
@@ -89,8 +89,13 @@ describe("VideoCard", () => {
     expect(mockPushVideo).toHaveBeenCalledWith(video);
   });
 
-  it("omits the watch link when the video has no link", () => {
-    renderCard(makeVideo({ link: "" }));
+  it.each([
+    ["an empty link", ""],
+    ["a javascript: link", "javascript:alert(1)"],
+    ["a data: link", "data:text/html,<script>alert(1)</script>"],
+    ["a scheme-relative link", "//www.youtube.com/watch?v=abc123"],
+  ])("omits the watch link for %s", (_name, link) => {
+    renderCard(makeVideo({ link }));
 
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });

--- a/service/vspo-schedule/v2/web/src/features/shared/components/Elements/Card/VideoCard.tsx
+++ b/service/vspo-schedule/v2/web/src/features/shared/components/Elements/Card/VideoCard.tsx
@@ -79,6 +79,12 @@ const StyledCardMedia = styled(Box)({
 });
 
 /**
+ * `link` is an unconstrained string on `videoSchema`, so an unexpected value could put a
+ * `javascript:` or `data:` URL into `href`. Allowlist absolute http(s) URLs instead.
+ */
+const HTTP_URL_PATTERN = /^https?:\/\//i;
+
+/**
  * Mirrors the thumbnail box so the watch link can be anchored to it while living
  * outside `CardActionArea` (an anchor may not be nested inside a button).
  * Transparent to pointer events so the thumbnail still opens the detail modal.
@@ -129,7 +135,7 @@ const watchLinkButtonSx = (theme: Theme) => ({
  * detail modal, and the watch link opens `video.link` on its source platform in a new tab.
  *
  * @precondition Must be rendered inside a `VideoModalContext` provider.
- * @postcondition Renders the watch link only when `video.link` is non-empty.
+ * @postcondition Renders the watch link only when `video.link` is an absolute http(s) URL.
  * Clicking the watch link never opens the detail modal.
  * @remarks Rendering is idempotent -- the component holds no state of its own.
  */
@@ -143,6 +149,7 @@ export const VideoCard: React.FC<Props> = ({
   const t = useTranslations("common");
   const platform = video.platform;
   const watchLabel = t(`videoCard.watchOn.${platform}`);
+  const watchUrl = HTTP_URL_PATTERN.test(video.link) ? video.link : undefined;
   return (
     <Box sx={{ position: "relative" }}>
       {highlight && (
@@ -172,11 +179,11 @@ export const VideoCard: React.FC<Props> = ({
           </StyledCardMedia>
           {children}
         </CardActionArea>
-        {video.link && (
+        {watchUrl && (
           <WatchLinkOverlay>
             <Tooltip title={watchLabel}>
               <IconButton
-                href={video.link}
+                href={watchUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={watchLabel}

--- a/service/vspo-schedule/v2/web/src/features/shared/components/Elements/Card/VideoCard.tsx
+++ b/service/vspo-schedule/v2/web/src/features/shared/components/Elements/Card/VideoCard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Box, Card, CardActionArea } from "@mui/material";
-import { styled } from "@mui/material/styles";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import { Box, Card, CardActionArea, IconButton, Tooltip } from "@mui/material";
+import { styled, type Theme } from "@mui/material/styles";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { PlatformIcon } from "@/features/schedule/pages/ScheduleStatus/components/LivestreamContent/PlatformIcon";
@@ -60,6 +61,7 @@ const PlatformIconWrapper = styled(Box)(({ theme }) => ({
 const StyledCard = styled(Card, {
   shouldForwardProp: (prop) => prop !== "highlightColor",
 })<{ highlightColor?: string }>(({ theme, highlightColor }) => ({
+  position: "relative",
   display: "flex",
   flexDirection: "column",
   height: "100%",
@@ -76,6 +78,61 @@ const StyledCardMedia = styled(Box)({
   objectFit: "contain",
 });
 
+/**
+ * Mirrors the thumbnail box so the watch link can be anchored to it while living
+ * outside `CardActionArea` (an anchor may not be nested inside a button).
+ * Transparent to pointer events so the thumbnail still opens the detail modal.
+ */
+const WatchLinkOverlay = styled(Box)({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  right: 0,
+  aspectRatio: "16 / 9",
+  pointerEvents: "none",
+  zIndex: 2,
+});
+
+/**
+ * Styles for the watch link. Declared as `sx` rather than `styled()` because
+ * `IconButton` must keep its overridable typing to accept anchor props.
+ */
+const watchLinkButtonSx = (theme: Theme) => ({
+  position: "absolute",
+  right: "8px",
+  bottom: "8px",
+  pointerEvents: "auto",
+  gap: "4px",
+  padding: "3px 8px 3px 6px",
+  minWidth: "24px",
+  minHeight: "24px",
+  borderRadius: "999px",
+  fontSize: "0.75rem",
+  fontWeight: 600,
+  lineHeight: 1.4,
+  color: theme.vars.palette.text.primary,
+  backgroundColor: "rgba(255, 255, 255, 0.9)",
+  boxShadow: theme.shadows[2],
+  "&:hover": {
+    backgroundColor: "rgb(255, 255, 255)",
+  },
+  [theme.breakpoints.down("sm")]: {
+    right: "4px",
+    bottom: "4px",
+    padding: "2px 6px 2px 4px",
+    fontSize: "0.7rem",
+  },
+});
+
+/**
+ * Thumbnail card for a video, with two independent targets: the card body opens the
+ * detail modal, and the watch link opens `video.link` on its source platform in a new tab.
+ *
+ * @precondition Must be rendered inside a `VideoModalContext` provider.
+ * @postcondition Renders the watch link only when `video.link` is non-empty.
+ * Clicking the watch link never opens the detail modal.
+ * @remarks Rendering is idempotent -- the component holds no state of its own.
+ */
 export const VideoCard: React.FC<Props> = ({
   video,
   highlight,
@@ -85,6 +142,7 @@ export const VideoCard: React.FC<Props> = ({
   const { pushVideo } = useVideoModalContext();
   const t = useTranslations("common");
   const platform = video.platform;
+  const watchLabel = t(`videoCard.watchOn.${platform}`);
   return (
     <Box sx={{ position: "relative" }}>
       {highlight && (
@@ -107,13 +165,33 @@ export const VideoCard: React.FC<Props> = ({
               priority={priority}
             />
             {video.type === "livestream" && (
-              <PlatformIconWrapper>
+              <PlatformIconWrapper aria-hidden>
                 <PlatformIcon platform={platform} />
               </PlatformIconWrapper>
             )}
           </StyledCardMedia>
           {children}
         </CardActionArea>
+        {video.link && (
+          <WatchLinkOverlay>
+            <Tooltip title={watchLabel}>
+              <IconButton
+                href={video.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={watchLabel}
+                sx={watchLinkButtonSx}
+              >
+                {platform === "unknown" ? (
+                  <OpenInNewIcon sx={{ fontSize: "18px" }} />
+                ) : (
+                  <PlatformIcon platform={platform} />
+                )}
+                {t("videoCard.watch")}
+              </IconButton>
+            </Tooltip>
+          </WatchLinkOverlay>
+        )}
       </StyledCard>
     </Box>
   );


### PR DESCRIPTION
## Current State

VideoCard displays video thumbnails with platform icons for livestreams, but provides no direct way to open the source video link from the card itself.

## Problem

Reaching a stream on its source platform takes three interactions: tap the card, wait for the fullscreen detail modal, then tap "watch". For users scanning several streams in a row that cost is paid on every card.

## Changes

- **VideoCard component**: Added a watch link overlaid on the bottom-right of the thumbnail that opens `video.link` on the source platform in a new tab
  - The button pairs the platform icon with a short "watch" label. The label is what distinguishes it from the decorative platform badge in the opposite corner — without it the same icon appears twice on one thumbnail and neither reads as actionable. Unknown platforms fall back to a generic "open in new" icon.
  - Rendered as a **sibling** of `CardActionArea`, not a descendant: an anchor may not be nested inside a button, and keeping it outside means its click never bubbles to the card handler (so no `stopPropagation` is needed).
  - An overlay wrapper mirrors the 16:9 thumbnail box and is transparent to pointer events, so only the button itself is carved out of the card's tap target.
  - Renders only when `video.link` is an absolute `http(s)` URL — see the scheme guard below.

- **Link scheme guard**: `link` is an unconstrained `z.string()` on `videoSchema`, so nothing in the API contract stops a `javascript:` or `data:` value from reaching `href`. The button allowlists absolute http(s) URLs rather than denylisting known-bad schemes. A link that fails the check is treated exactly like a missing one: the button is omitted and the card body still opens the detail modal.

- **Accessibility (WCAG 2.2 AA)**: `aria-label` carries the platform-specific name ("Watch on YouTube") and contains the visible label as a substring (2.5.3 Label in Name). The decorative platform badge is now `aria-hidden` so the platform is not announced twice. A tooltip exposes the same label on hover and keyboard focus.

- **Internationalization**: Added `videoCard.watch` and `videoCard.watchOn.*` keys across all supported locales (ja, en, cn, tw, ko).

- **Testing**: Added unit tests covering the link's href/target/rel, the platform-specific accessible name, the visible label, that the link click does not open the modal, that the card body click still does, the unknown-platform fallback, and a table-driven case that no link renders for empty, `javascript:`, `data:`, or scheme-relative values.

- **Storybook**: `LivestreamCard` stories could not render at all before this change, because `VideoCard` calls `useVideoModalContext`, which throws outside its provider. The preview now supplies a no-op context value and the real `ja` messages, `staticDirs` serves `public/` so platform icons resolve, and the story thumbnail is inlined as a data URI (the previous `via.placeholder.com` URLs no longer resolve).

- **Documentation**: Added JSDoc to VideoCard describing preconditions, postconditions, and idempotency.

## Impact

- `VideoCard` is shared by the schedule, clips, and freechat lists, so all three gain the shortcut from one change.
- The card body keeps its existing behavior of opening the detail modal — no breaking changes to component props or API.

## Note for reviewers

The feature spec was written before implementation and lives at `docs/plan/video-card-watch-link/`, but it cannot be committed: `.gitignore:4` excludes `docs/plan/` as "generated docs (not tracked)", while `AGENTS.md` L18-21 requires feature work to proceed from a spec there. That contradiction is discussed in an unresolved review thread and is a maintainer decision, not something this PR resolves on its own.