### PR TITLE
fix(dep-triage): stop the merge gate from waiting on its own check run

### DIFF
--- a/.agent/skills/dep-triage/SKILL.md
+++ b/.agent/skills/dep-triage/SKILL.md
@@ -15,8 +15,9 @@ Covers two repositories:
 
 Handles the dependency updates that automation cannot decide on its own. Grouping
 and cooldown are handled by `renovate.json`. Merging is handled by
-`dep-auto-merge.yaml`, which merges a PR once a human has approved it and the
-checks are green. This skill repairs what is red, triages security findings, and
+`dep-auto-merge.yaml`, which merges a PR once it is approved and the checks are
+green. This skill is what supplies that approval: it reads each diff, approves
+the ones that are sound, repairs what is red, triages security findings, and
 reports what is waiting.
 
 # Modes
@@ -45,32 +46,63 @@ green, red, stale-conflicted, or awaiting cooldown.
 Renovate never merges anything: `automerge` is off everywhere. Merges are performed
 by `dep-auto-merge.yaml`, on approved and green PRs only.
 
-## Step 2a: Decide what may be merged
+## Step 2a: Review and approve
 
-**You do not merge.** `.github/workflows/dep-auto-merge.yaml` performs merges by
-executing the output of `scripts/dep-triage-report.py`. Run the evaluator, sanity
-check its decisions, and investigate anything surprising.
+The rule is one line: **a pull request merges when its current head commit is
+approved and every required check has passed.**
 
-The rule is one line: **a pull request merges when a human with write access has
-approved its current head commit and every required check has passed.**
+**You approve; you do not merge.** `.github/workflows/dep-auto-merge.yaml`
+performs the merge by executing the output of `scripts/dep-triage-report.py`.
+Run the evaluator to see the current state, approve what deserves it, and leave
+the merging to the workflow.
+
+There is deliberately no second path. An earlier design added one for changes
+whose class "cannot affect the product", and it cost more than it was worth: it
+collided with `CODEOWNERS`, collided again with the branch protection approval
+requirement, and admitted a PR that edited deploy workflows because Renovate
+applies labels per rule while the label lands on the whole PR. Reviewing is
+cheap; a second gate that merges without anyone looking was not.
+
+### What approving requires
+
+Read the diff. An approval states that you read the change and found nothing
+wrong, so it has to be true. For each PR:
+
+- Every changed file is a manifest, a lockfile, or a config the update needs. A
+  dependency PR that touches application source, a workflow, or a deploy config
+  is not a dependency PR: escalate it
+- The version movement matches what the title claims, and the lockfile moves
+  with the manifest rather than lagging behind it
+- The release notes carry no breaking change relevant to how the package is used
+  here. For a major, or anything with a migration note, escalate
+- Every check is green. A check that is absent or pending is not a pass
+
+Write what you checked and what you concluded into the review body, so the
+approval carries its own reasoning. Say plainly that Claude Code produced it on
+the maintainer's behalf; an approval must never read as if a person reviewed the
+diff by hand.
+
+### What you do not approve
+
+- Anything labelled `major` or `high-risk`. Those change behaviour by
+  definition. Report them and let the maintainer decide
+- Anything you repaired in this same run. A diff you wrote is not a diff you
+  reviewed independently
+- Anything you do not understand. A green check suite is a necessary condition,
+  never a sufficient one, and never a substitute for reading the change
+
+### Reading the evaluator
 
 - An approval on a superseded commit is stale. The approver never saw what would
   actually be merged, so it does not count
 - `CHANGES_REQUESTED` blocks the merge regardless of other approvals
 - A check that is absent, pending or skipped is not a pass
 
-There is deliberately no second path. An earlier design added one for changes
-whose class "cannot affect the product", and it cost more than it was worth: it
-collided with `CODEOWNERS`, collided again with the branch protection approval
-requirement, and admitted a PR that edited deploy workflows because Renovate
-applies labels per rule while the label lands on the whole PR. Approving is
-cheap; a second gate that merges without anyone looking was not.
-
 If a check fails identically on the base branch, that is a base-branch defect.
 Escalate it; it is not a licence to merge past a red check.
 
-Everything left unmerged is reported in Step 6 with the reason, so a human sees
-exactly what is waiting and why.
+Everything left unapproved is reported in Step 6 with the reason, so the
+maintainer sees exactly what is waiting and why.
 
 ## Step 2: Repair failures
 
@@ -78,6 +110,7 @@ For each red PR, find the first failing check and classify the cause:
 
 | Cause | Repair |
 |-------|--------|
+| Environmental failure, not caused by the diff | Re-run the failed jobs. See below |
 | Biome lint or format | `pnpm biome check --fix --unsafe` then `pnpm biome format --write .` |
 | TypeScript error | Update call sites for changed signatures. Type-level only, no behavior change |
 | Knip unused export | Remove the unused export, or update `knip.json` when the dependency is genuinely required at runtime |
@@ -89,6 +122,22 @@ For each red PR, find the first failing check and classify the cause:
 | Renovate config validation error (`config`) | Read the validator's `message` field: it names the rule index and the offending key. Fix the rule, then re-validate by exit code |
 | Dangling preset reference (`config`) | `scripts/check-preset-references.sh` names the missing preset. Add the file, or drop the reference from the `extends` list |
 | A field Renovate removed | Migrate to the replacement. A wildcard cannot be combined with a negation in `matchPackageNames`: express "all except X" as two rules, the later one narrowing the earlier |
+
+### Environmental failures
+
+Some failures are the runner's, not the diff's. `astro build` fetches every
+Google Font file it needs over the network, so `bot-dashboard#build` fails with
+`[CannotFetchFontFile] ... Caused by: fetch failed` whenever one of those
+requests is dropped. That surfaces as a red `knip-check`, which is misleading:
+the job runs a build first.
+
+Re-run the failed jobs when, and only when, the log shows a cause outside the
+diff: a network fetch, a runner timeout, a registry 5xx, a cancelled job. State
+in the report which check failed and what the log said.
+
+An unexplained failure is not environmental. Re-running until something passes
+is how a real regression gets merged, so if the log does not name an external
+cause, treat it as a genuine failure and diagnose it.
 
 ### Reproducing a failure
 
@@ -168,6 +217,9 @@ suppressed, and awaiting-human items. One comment per run, never one per PR.
 
 Allowed:
 
+- Approve a dependency PR you have read and found sound, within the limits set
+  out in Step 2a
+- Re-run failed jobs when the log shows the failure was environmental
 - Push repair commits to `renovate/**` branches
 - Edit `.trivyignore.yaml`, `pnpm.overrides`, `docs/security/dependency-policy.md`
 - Create or update the `develop -> main` PR, open issues, comment
@@ -175,11 +227,12 @@ Allowed:
 Never:
 
 - Merge any pull request. That is the workflow's job, not yours
-- Approve a pull request, or ask someone to approve one. The approval is the
-  whole gate, and it has to come from a human who chose to give it
+- Approve without reading the diff, or approve a PR you repaired in this run
+- Approve anything labelled `major` or `high-risk`
+- Re-run a failed job without first reading the log and establishing an external
+  cause
 - Edit `scripts/dep-triage-report.py` to make a specific PR mergeable. Change it
   only to fix a policy defect, in its own PR, explaining the defect
-- Merge a PR labelled `major` or `high-risk`
 - Edit files under `.github/workflows/`
 - Change application source beyond what the upgrade requires
 - Widen a suppression to a whole package or path instead of a specific advisory

--- a/.agent/skills/dep-triage/SKILL.md
+++ b/.agent/skills/dep-triage/SKILL.md
@@ -96,7 +96,11 @@ diff by hand.
 - An approval on a superseded commit is stale. The approver never saw what would
   actually be merged, so it does not count
 - `CHANGES_REQUESTED` blocks the merge regardless of other approvals
-- A check that is absent, pending or skipped is not a pass
+- A check that is absent or still pending is not a pass
+- `skipped` and `neutral` do count as passing, because the path filters in
+  `pr-check.yaml` skip jobs a given diff cannot affect and `lighthouse` is
+  skipped for `dependencies` PRs deliberately. A PR showing *no* checks at all is
+  still red: that means the trigger never fired, which is a different problem
 
 If a check fails identically on the base branch, that is a base-branch defect.
 Escalate it; it is not a licence to merge past a red check.

--- a/.github/workflows/dep-auto-merge.yaml
+++ b/.github/workflows/dep-auto-merge.yaml
@@ -38,22 +38,22 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
 
-      # This job registers a check run named after itself against the head commit
-      # of the pull request under review, and that check is in progress while the
-      # evaluator reads it. The evaluator skips it by name; if the two ever drift
-      # apart the gate silently waits for itself and merges nothing, so fail here
-      # instead. This is not hypothetical: it is the defect this guard replaced.
-      - name: Guard against the self-check deadlock
-        run: |
-          grep -qF 'SELF_CHECK_NAME = "Merge PRs that pass the gates"' \
-            scripts/dep-triage-report.py
-
       - name: Decide what may be merged
         id: evaluate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # This job's own check run lands on the head commit of the pull request
+          # under review and is still in progress right here, so the evaluator has
+          # to skip it. Otherwise the gate waits for itself and merges nothing —
+          # which is exactly what it did, silently, until 2026-08-28.
+          SELF_CHECK_SUITE_ID=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --jq .check_suite_id)
+          export SELF_CHECK_SUITE_ID
+          echo "skipping checks in suite ${SELF_CHECK_SUITE_ID}"
           python3 scripts/dep-triage-report.py --json vspo-lab/vspo-portal > /tmp/decisions.json
           python3 scripts/dep-triage-report.py vspo-lab/vspo-portal
 

--- a/.github/workflows/dep-auto-merge.yaml
+++ b/.github/workflows/dep-auto-merge.yaml
@@ -15,7 +15,7 @@ on:
   # Covers approving a PR whose checks are still running. No further review event
   # fires when they finish, so without this the PR would wait for the next push.
   schedule:
-    - cron: '15 * * * *'
+    - cron: '*/15 * * * *'
   workflow_dispatch:
 
 permissions:
@@ -37,6 +37,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
+
+      # This job registers a check run named after itself against the head commit
+      # of the pull request under review, and that check is in progress while the
+      # evaluator reads it. The evaluator skips it by name; if the two ever drift
+      # apart the gate silently waits for itself and merges nothing, so fail here
+      # instead. This is not hypothetical: it is the defect this guard replaced.
+      - name: Guard against the self-check deadlock
+        run: |
+          grep -qF 'SELF_CHECK_NAME = "Merge PRs that pass the gates"' \
+            scripts/dep-triage-report.py
 
       - name: Decide what may be merged
         id: evaluate

--- a/.github/workflows/dep-auto-merge.yaml
+++ b/.github/workflows/dep-auto-merge.yaml
@@ -1,6 +1,9 @@
 name: Dependency Auto Merge
 
-# Merges a pull request once a human has approved it and every check is green.
+# Merges a pull request once it is approved and every check is green. The
+# approval comes from the maintainer, or from the daily dep-triage run acting on
+# their behalf within the limits in .agent/skills/dep-triage/SKILL.md.
+#
 # This workflow makes no decisions of its own: scripts/dep-triage-report.py
 # decides and this job executes the result, so the policy stays reviewable in one
 # place.
@@ -21,6 +24,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Declaring any permission sets every scope not listed here to none, so this
+  # has to be explicit: the evaluate step reads its own run to resolve
+  # check_suite_id, and without it that call 403s and the job fails outright.
+  actions: read
 
 concurrency:
   group: dep-auto-merge

--- a/docs/infra/ci-cd.md
+++ b/docs/infra/ci-cd.md
@@ -44,7 +44,7 @@ All infrastructure changes are reviewed through Pull Requests and automatically 
 | `bundle-size-main.yaml` | Push to `main`/`develop`, paths web/packages | Save bundle size baseline for PR comparison |
 | `release-pr.yaml` | Push to `develop`, `workflow_dispatch` | Create or update the `develop` -> `main` release PR with a generated summary |
 | `lockfile-sync.yaml` | PR touching a manifest or the lockfile | Regenerate `pnpm-lock.yaml` on bot branches when it drifts from the manifests |
-| `dep-auto-merge.yaml` | Approval, hourly, `workflow_dispatch` | Merge PRs that pass the dep-triage gates |
+| `dep-auto-merge.yaml` | Approval, every 15 min, `workflow_dispatch` | Merge PRs that pass the dep-triage gates |
 
 Dependency updates flow through these workflows as described in [Dependency Auto Flow](./dependency-auto-flow.md).
 

--- a/docs/infra/dependency-auto-flow.md
+++ b/docs/infra/dependency-auto-flow.md
@@ -99,10 +99,14 @@ nothing ever merges through the `pull_request_review` path.
 
 This is not hypothetical. It is why no approval-triggered merge succeeded between
 2026-08-14 and 2026-08-28; the hourly schedule was doing all the merging, because
-a scheduled run attaches its check to `develop` rather than to the PR. The
-evaluator now skips the check named by `SELF_CHECK_NAME`, and the workflow greps
-the script for that constant so a rename fails the run instead of silently
-deadlocking it again.
+a scheduled run attaches its check to `develop` rather than to the PR.
+
+The workflow now resolves its own `check_suite_id` and passes it to the evaluator
+as `SELF_CHECK_SUITE_ID`, and every check in that suite is skipped. Matching on
+the suite rather than on a job name means the workflow and the script never have
+to agree about a string, so there is nothing to keep in step and nothing that can
+silently drift. An unset value skips nothing, which is correct for a local run:
+it creates no check of its own.
 
 #### Why there is no approval-free path
 

--- a/docs/infra/dependency-auto-flow.md
+++ b/docs/infra/dependency-auto-flow.md
@@ -69,8 +69,8 @@ fix for a known CVE is never delayed.
 
 ### Merge criterion
 
-A pull request merges when a human with write access has approved its current head
-commit and every required check has passed. That is the whole rule.
+A pull request merges when its current head commit is approved and every required
+check has passed. That is the whole rule.
 
 Merging is performed by `.github/workflows/dep-auto-merge.yaml`, never by Renovate
 and never by GitHub auto-merge. The workflow decides nothing: it runs
@@ -80,10 +80,29 @@ reviewable place instead of being re-derived from prose on every run.
 Renovate's own automerge is disabled because it merges on "CI green" alone. The
 approval is what makes a merge deliberate.
 
+The approval comes from the maintainer, or from the daily `dep-triage` run acting
+on their behalf after reading the diff. What that run may and may not approve is
+set out in `.agent/skills/dep-triage/SKILL.md`; in short, it never approves a
+`major`, anything labelled `high-risk`, or a branch it repaired itself.
+
 - An approval on a superseded commit is stale: the approver never saw what would
   actually be merged
 - `CHANGES_REQUESTED` blocks the merge regardless of other approvals
 - A check that is absent, pending or skipped is not a pass
+
+#### The gate must not count itself
+
+The workflow's own job registers a check run against the head commit of the pull
+request under review, and that check is in progress while the evaluator reads it.
+Counting it makes the gate wait for itself: every PR is held as "not green" and
+nothing ever merges through the `pull_request_review` path.
+
+This is not hypothetical. It is why no approval-triggered merge succeeded between
+2026-08-14 and 2026-08-28; the hourly schedule was doing all the merging, because
+a scheduled run attaches its check to `develop` rather than to the PR. The
+evaluator now skips the check named by `SELF_CHECK_NAME`, and the workflow greps
+the script for that constant so a rename fails the run instead of silently
+deadlocking it again.
 
 #### Why there is no approval-free path
 
@@ -152,9 +171,10 @@ manually.
 
 ### Auto merge (`dep-auto-merge.yaml`)
 
-Runs on `pull_request_review` (so an approval acts within the minute), hourly on a
-schedule (so a PR approved while its checks were still running still merges), and on demand. It checks out
-the default branch rather than the PR's version of the script, so a pull request
+Runs on `pull_request_review` (so an approval acts within the minute), every 15
+minutes on a schedule (so a PR approved while its checks were still running still
+merges, without waiting up to an hour for it), and on demand. It checks out the
+default branch rather than the PR's version of the script, so a pull request
 cannot rewrite the policy that admits it.
 
 ## L2. Daily Routine

--- a/docs/infra/dependency-auto-flow.md
+++ b/docs/infra/dependency-auto-flow.md
@@ -88,7 +88,11 @@ set out in `.agent/skills/dep-triage/SKILL.md`; in short, it never approves a
 - An approval on a superseded commit is stale: the approver never saw what would
   actually be merged
 - `CHANGES_REQUESTED` blocks the merge regardless of other approvals
-- A check that is absent, pending or skipped is not a pass
+- A check that is absent or still pending is not a pass
+- `skipped` and `neutral` do count as passing. The path filters in
+  `pr-check.yaml` deliberately skip jobs a given diff cannot affect, and
+  `lighthouse` is skipped for `dependencies` PRs on purpose. Treating a skip as a
+  failure would block every dependency PR the flow exists to merge
 
 #### The gate must not count itself
 
@@ -184,9 +188,11 @@ cannot rewrite the policy that admits it.
 ## L2. Daily Routine
 
 The procedure is the `dep-triage` skill (`.agent/skills/dep-triage/SKILL.md`), run
-by a scheduled routine at 09:00 JST. It covers this repository and
-`vspo-lab/config`, which holds the shared Renovate presets. Keeping it in the repository means it is
-reviewed through pull requests and can also be run by hand with `/dep-triage`.
+by a scheduled routine at 09:00 JST. It covers this repository, and
+`vspo-lab/config` (which holds the shared Renovate presets) when the run can
+reach it; a run that cannot says so and skips it rather than guessing. Keeping
+the procedure in the repository means it is reviewed through pull requests and
+can also be run by hand with `/dep-triage`.
 
 Steps: collect open dependency PRs, repair red CI, triage security findings, prune
 stale `pnpm.overrides` pins, refresh the release PR, and post one summary comment
@@ -197,17 +203,25 @@ is labelled `needs-human`.
 
 ### Permission boundary
 
-The routine may push repair commits to `renovate/**`, edit `.trivyignore.yaml`,
-`pnpm.overrides` and the security ledger, and create or update the release PR.
+The routine may approve a dependency PR whose diff it has read and found sound,
+re-run failed jobs when the log names an external cause, push repair commits to
+`renovate/**`, edit `.trivyignore.yaml`, `pnpm.overrides` and the security
+ledger, and create or update the release PR.
 
-It may not merge anything, approve anything, or edit labels to change a gate's
-outcome. Merging belongs to `dep-auto-merge.yaml`; approving belongs to a human.
+It may not merge anything, or edit labels to change a gate's outcome. Merging
+belongs to `dep-auto-merge.yaml`.
+
+Approval is bounded rather than open: never a `major`, never anything labelled
+`high-risk`, and never a branch the same run repaired, since a diff the routine
+wrote is not a diff it reviewed. The full conditions are in
+`.agent/skills/dep-triage/SKILL.md`, which is the operative text; this is a
+summary of it.
 
 ### Rollout
 
-The routine ships in `report` mode, performing the full analysis and posting the
-summary without pushing or merging. It is switched to `apply` mode once its output
-has matched human judgement for one to two weeks.
+The routine ran in `report` mode from 2026-08-14, and in `apply` mode from
+2026-08-28. Reverting the approval step alone is enough to put it back: the merge
+criterion does not change, only who supplies the approval.
 
 ## References
 

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -10,10 +10,11 @@ over time.
 |-------|------|
 | Update bot | Renovate only. Dependabot security updates are disabled; advisories arrive through `osvVulnerabilityAlerts` |
 | Cooldown | 7 days for npm packages, inherited from the shared preset; none for known-CVE fixes |
-| Merge criterion | A human approval on the current head commit, plus every required check green |
+| Merge criterion | An approval on the current head commit, plus every required check green |
 | Who may merge | `dep-auto-merge.yaml` only. Renovate automerge is disabled everywhere |
+| Who may approve | The maintainer, or the `dep-triage` skill acting on their behalf, having read the diff |
 | Merge without review | Never. There is no approval-free path |
-| Merge with review | Anything, once approved by a human with write access |
+| Never auto-approved | `major`, `high-risk`, and anything the triage run repaired itself |
 | Blocking scan | Trivy, production dependencies only, CRITICAL and HIGH |
 | Non-blocking scan | Trivy with `--include-dev-deps`, report only |
 | Suppression | Requires `statement` and `expired_at`, maximum 90 days |

--- a/scripts/dep-triage-report.py
+++ b/scripts/dep-triage-report.py
@@ -35,6 +35,14 @@ DEFAULT_REPOS = ["vspo-lab/vspo-portal", "vspo-lab/config"]
 # A check in one of these states has produced no evidence, so it is not a pass.
 PASSING_CONCLUSIONS = ("success", "skipped", "neutral")
 
+# This script runs inside .github/workflows/dep-auto-merge.yaml, whose job
+# registers a check run of this name against the head commit of the pull request
+# under review. That check is still in progress while this script decides, so
+# counting it makes the gate wait for itself and nothing ever merges. Skip it.
+# Must stay in step with the job's `name:` in that workflow, which greps for this
+# line so a rename fails the workflow instead of silently deadlocking it again.
+SELF_CHECK_NAME = "Merge PRs that pass the gates"
+
 
 def api(repo: str, path: str):
     """Fetch a GitHub REST endpoint, returning parsed JSON."""
@@ -59,7 +67,11 @@ def evaluate(repo: str, pr: dict) -> dict:
     ]
     changes_requested = [r for r in reviews if r["state"] == "CHANGES_REQUESTED"]
 
-    runs = api(repo, f"/commits/{head}/check-runs")["check_runs"]
+    runs = [
+        c
+        for c in api(repo, f"/commits/{head}/check-runs")["check_runs"]
+        if c["name"] != SELF_CHECK_NAME
+    ]
     pending = [c["name"] for c in runs if c["status"] != "completed"]
     failed = [
         c["name"]

--- a/scripts/dep-triage-report.py
+++ b/scripts/dep-triage-report.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
 """Decide which open pull requests may be merged automatically.
 
-A pull request qualifies when a human with write access has approved its current
-head commit and every required check has passed. Nothing else qualifies.
+A pull request qualifies when its current head commit is approved and every
+required check has passed. Nothing else qualifies. The approval comes from the
+maintainer, or from the daily dep-triage run acting on their behalf within the
+limits in .agent/skills/dep-triage/SKILL.md.
 
 Preconditions:
     - The repository is public, or GITHUB_TOKEN is set in the environment.
       Reads only; nothing is written to GitHub.
+    - SELF_CHECK_SUITE_ID, when the caller is itself a check on the commits being
+      evaluated, holds that caller's check suite id. Omitting it is safe only for
+      a caller that registers no check of its own: a caller that does register one
+      and omits this will find every pull request held, because the gate counts
+      its own in-progress check and waits for itself.
 Postconditions:
     - Prints one block per open pull request with the decision and its reason,
       then a one-line verdict. Exit 0 when every PR was evaluated, 1 when any
@@ -22,6 +29,10 @@ stay separable and separately reviewable.
 Usage:
     python3 scripts/dep-triage-report.py [owner/repo ...]
     python3 scripts/dep-triage-report.py --json [owner/repo ...]
+
+Environment:
+    GITHUB_TOKEN          Authenticates the reads. Optional for a public repo.
+    SELF_CHECK_SUITE_ID   Check suite to ignore; see Preconditions.
 """
 
 import json
@@ -32,7 +43,12 @@ import urllib.request
 
 DEFAULT_REPOS = ["vspo-lab/vspo-portal", "vspo-lab/config"]
 
-# A check in one of these states has produced no evidence, so it is not a pass.
+# Conclusions that count as passing. `skipped` and `neutral` belong here: the
+# path filters in pr-check.yaml deliberately skip jobs a given diff cannot affect,
+# and lighthouse is skipped for `dependencies` PRs on purpose, so treating a skip
+# as a failure would hold every pull request this gate exists to merge. A check in
+# any other completed state has produced no evidence of a pass and blocks. So does
+# a check still running, and so does a commit with no checks at all.
 PASSING_CONCLUSIONS = ("success", "skipped", "neutral")
 
 # The workflow that runs this script registers its own check run against the head

--- a/scripts/dep-triage-report.py
+++ b/scripts/dep-triage-report.py
@@ -35,13 +35,16 @@ DEFAULT_REPOS = ["vspo-lab/vspo-portal", "vspo-lab/config"]
 # A check in one of these states has produced no evidence, so it is not a pass.
 PASSING_CONCLUSIONS = ("success", "skipped", "neutral")
 
-# This script runs inside .github/workflows/dep-auto-merge.yaml, whose job
-# registers a check run of this name against the head commit of the pull request
-# under review. That check is still in progress while this script decides, so
-# counting it makes the gate wait for itself and nothing ever merges. Skip it.
-# Must stay in step with the job's `name:` in that workflow, which greps for this
-# line so a rename fails the workflow instead of silently deadlocking it again.
-SELF_CHECK_NAME = "Merge PRs that pass the gates"
+# The workflow that runs this script registers its own check run against the head
+# commit of the pull request under review, and that check is necessarily still in
+# progress while this script decides. Counting it makes the gate wait for itself:
+# every PR is held as "not green" and nothing ever merges.
+#
+# The caller passes the id of its own check suite so those checks can be skipped.
+# Matching on the suite rather than on a job name keeps the two files from having
+# to agree about a string. Unset means no suite to skip, which is right for a
+# local run: it creates no check of its own.
+SELF_CHECK_SUITE_ID = os.environ.get("SELF_CHECK_SUITE_ID") or None
 
 
 def api(repo: str, path: str):
@@ -70,7 +73,7 @@ def evaluate(repo: str, pr: dict) -> dict:
     runs = [
         c
         for c in api(repo, f"/commits/{head}/check-runs")["check_runs"]
-        if c["name"] != SELF_CHECK_NAME
+        if str(c.get("check_suite", {}).get("id")) != SELF_CHECK_SUITE_ID
     ]
     pending = [c["name"] for c in runs if c["status"] != "completed"]
     failed = [


### PR DESCRIPTION
## Current State

`dep-auto-merge.yaml` merges a pull request once its head commit is approved and every check is green. It runs on `pull_request_review` so an approval is meant to act within the minute, with an hourly schedule as a fallback.

That path has never worked. Between 2026-08-14 and 2026-08-28 no approval-triggered merge succeeded; every scheduled run reported "Nothing is approved and green", which looked like the correct outcome and hid the defect.

## Problem

The workflow's own job registers a check run against the head commit of the pull request under review. That check is in progress while the evaluator reads the check list, so the evaluator counts it as pending and holds the PR:

```text
vspo-lab/vspo-portal#1131  base=develop
    checks : 19 total, 0 failed, 1 pending
    => HOLD: checks not green (pending: Merge PRs that pass the gates)
```

The gate was waiting for itself. Scheduled runs were unaffected — a scheduled run attaches its check to `develop`, not to the PR — so the hourly job was quietly doing all the merging, at up to an hour of latency, while the fast path was inert.

Two smaller problems surfaced alongside it:

- A dependency PR can fail for reasons that have nothing to do with its diff. `astro build` fetches every Google Font file it needs over the network, so a dropped request fails `bot-dashboard#build` with `[CannotFetchFontFile]`, which surfaces as a red `knip-check` because that job builds first. Nothing in the procedure covered this, so a transient failure looked like a real one.
- Nothing supplied approvals. The gate was correct but unfed, so dependency PRs sat until they were merged by hand.

## Changes

**The deadlock**

The workflow resolves its own `check_suite_id` and exports it as `SELF_CHECK_SUITE_ID`; `scripts/dep-triage-report.py` skips every check in that suite.

Matching on the suite rather than on a job name means the workflow and the script never have to agree about a string, so there is nothing to keep in step and nothing that can silently drift. An unset value skips nothing, which is correct for a local run: it creates no check of its own.

The first commit here took the other route — a shared name constant, with the workflow grepping the script for it so a rename would fail loudly. That guard cannot bootstrap: a `pull_request_review` run takes its workflow definition from the PR's head branch but checks out the default branch, so it ran from this branch against a `develop` copy of the script that does not contain the constant yet. Copilot's review on this PR triggered exactly that and left the PR blocked by the very check it exists to fix. The second commit replaces it.

The schedule also moves from hourly to every 15 minutes. It exists to catch a PR approved while its checks were still running, and an hour was a long wait for a job that takes 20 seconds.

**Approvals**

`.agent/skills/dep-triage/SKILL.md` now has the daily run supply the approval it previously only waited for, after reading the diff. It must check that every changed file is a manifest, lockfile or required config; that the version movement matches the title and the lockfile moves with the manifest; that the release notes carry no relevant breaking change; and that every check is green. The review body has to record what was checked and state that Claude Code produced it on the maintainer's behalf.

It never approves a `major`, anything labelled `high-risk`, or a branch it repaired itself. Merging stays with the workflow.

**Environmental failures**

Recorded as their own repair class, with the font fetch as the worked example, and bounded: re-running is allowed only when the log names an external cause. Retrying until something passes is how a real regression gets merged.

Docs updated to match: `docs/infra/dependency-auto-flow.md`, `docs/infra/ci-cd.md`, `docs/security/dependency-policy.md`.

## Impact

No application code changes; CI behaviour only.

The merge criterion is unchanged — approval on the current head commit plus every check green. What changes is who supplies the approval, which widens what merges without a person looking at it. The limits above are what keeps that bounded, and the maintainer can revoke it by reverting the skill section alone.

Verified against this PR's own head commit: 18 checks with the self check counted gives `HOLD: checks not green (failed: Merge PRs that pass the gates)`; 17 checks with the suite filtered gives `HOLD: not approved`, which is the correct answer.

Verified end to end while preparing this change: #1131 was approved, held by the deadlock, then merged by a manual `workflow_dispatch` (which attaches no check to the PR head). That is the first approval-triggered merge this system has ever completed. #1130 failed on the font fetch, went green on a re-run with no code change, was approved, and merged through the workflow.