### PR TITLE
fix(renovate): point the shared preset at renovate/default.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>vspo-lab/config//renovate", ":dependencyDashboard"],
+  "extends": ["local>vspo-lab/config//renovate/default", ":dependencyDashboard"],
   "timezone": "Asia/Tokyo",
   "baseBranches": ["develop"],
   "schedule": ["* 0-3 * * *"],
@@ -9,6 +9,9 @@
   "prHourlyLimit": 2,
   "internalChecksFilter": "strict",
   "automerge": false,
+  "pin": {
+    "automerge": false
+  },
   "osvVulnerabilityAlerts": true,
   "lockFileMaintenance": {
     "enabled": true,
@@ -74,6 +77,11 @@
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true,
       "addLabels": ["major"]
+    },
+    {
+      "description": "Renovate never merges anything here. dep-auto-merge.yaml is the only merge path, and it requires an approval on the current head plus green checks. The shared preset enables automerge for @types below major (automergeTypesMinor) and for pin updates (automergePin); both would bypass that gate, so this rule -- last, and matching everything -- turns automerge back off. Remove it only together with those presets.",
+      "matchPackageNames": ["*"],
+      "automerge": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>vspo-lab/config//renovate/default", ":dependencyDashboard"],
+  "extends": [
+    "local>vspo-lab/config//renovate/default",
+    ":dependencyDashboard"
+  ],
   "timezone": "Asia/Tokyo",
   "baseBranches": ["develop"],
   "schedule": ["* 0-3 * * *"],


### PR DESCRIPTION
> **Draft on purpose. Do not merge before [vspo-lab/config#14](https://github.com/vspo-lab/config/pull/14)** — see *Impact*. That PR is open and safe to merge on its own; this one goes ready for review once it lands.

## Current State

`renovate.json` extends `local>vspo-lab/config//renovate`. That reads as "the `renovate` directory of `vspo-lab/config`", and it has never meant that.

Renovate's `parsePreset` matches it against `nonScopedPresetWithSubdirRegex`, where the segment after `//` is the *file*, and a `presetPath` only exists if there is a further `/`:

```
local>vspo-lab/config//renovate
  -> repo=vspo-lab/config  presetPath=undefined  presetName=renovate
  -> fetches: renovate.json          (repository root)
```

So the shared presets have never loaded. What loaded instead is `vspo-lab/config`'s own `renovate.json` — the config repo's self-configuration. It is a valid file, so nothing errored and nothing complained.

Verified against `renovate@42.99.0`'s own `parsePreset` and `fetchPreset`, not inferred from the docs.

That also explains two things that were previously blamed elsewhere:

- The **7-day `minimumReleaseAge` cooldown has never been in effect.** Renovate proposed `next` 16.3.4 two hours after publication (#1138); `js-yaml`, `devalue` and `svgo` were merged 1.9, 2.2 and 6.2 days after publication. Full evidence in #1140.
- **`pinGitHubActionDigests` has never been in effect** — every third-party action in `.github/workflows/` is still pinned by tag, not digest.
- The `no-runtime-impact` label leaking onto a PR that touched deploy workflows, described in the commit message of #1123, came from the config repo's own `packageRules` being loaded into this repository.

## Problem

The supply-chain cooldown the repository is documented to have is not running. `pnpm-workspace.yaml` says its `minimumReleaseAge` "matches the npm cooldown in the shared Renovate preset ... so a manual install cannot pull in a version that Renovate would still be holding back" — but nothing was holding it back, and pnpm's copy is switched off for the 15 packages in `minimumReleaseAgeExclude`.

Left alone, #1138 also cannot converge: each `next` release retargets the PR and restarts pnpm's clock, so it stays red and re-burns the check suite on every rebase.

## Changes

- `extends`: `local>vspo-lab/config//renovate` → `local>vspo-lab/config//renovate/default`, which resolves to `renovate/default.json`.
- Added `"pin": { "automerge": false }` and a final catch-all `packageRule` with `"automerge": false`.

The second change is not cosmetic. Turning the preset chain on also turns on `automergeTypesMinor` (`automerge: true` for `@types/**` below major) and `automergePin` (`pin.automerge: true`). Renovate merging anything here would bypass the entire gate — `dep-auto-merge.yaml` is the only merge path, and it requires an approval on the current head plus green checks. The catch-all rule is last, so it wins over the preset's rules; `pin.automerge` is set at top level because update-type config is not reached by a `packageRule`.

If you would rather drop `automergeTypesMinor`/`automergePin` from the org preset instead, remove this rule at the same time — not before.

Validated with `npx --package renovate -c 'renovate-config-validator'`, exit 0.

## Impact

**Ordering — this PR must land second.** Until [vspo-lab/config#14](https://github.com/vspo-lab/config/pull/14) merges, `vspo-lab/config`'s `renovate/default.json` still extends `github>vspo-lab/config/renovate:<name>` (single slash, colon). That parses to repository `vspo-lab/config/renovate`, which does not exist:

```
github>vspo-lab/config/renovate:minimumReleaseAge
  -> repo=vspo-lab/config/renovate  presetName=minimumReleaseAge   # no such repo
```

Today those references are unreachable, because `default.json` itself is never loaded. Merging this PR first makes `default.json` load and every one of its eight sub-presets fail — turning a silent misresolution into a hard preset error, which stops Renovate from raising PRs at all. Config first, then this; it is a no-op change in behaviour until then, and correct after.

**Once both land**, expect a burst of new PRs, all of it intended and none of it merging on its own:

- Digest-pin PRs for the third-party actions (`aquasecurity/trivy-action`, `cloudflare/wrangler-action`, `dorny/paths-filter`, `peter-evans/*`, `stefanzweifel/*`, `treosh/*`, `pnpm/action-setup`). `actions/*` stays on tags by design.
- Dependency PRs slow down: nothing is proposed until it is seven days old. #1138 should stop resetting and converge.
- `groupLinters` starts grouping linter updates; this repo's own `dev-dependencies` rule is later and still wins where they overlap.
- No change from `schedule` or `vulnerabilityAlerts` — this repository already overrides both.

**Not addressed here:** `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` still waives pnpm's cooldown for 15 packages, including `vite`, `postcss`, `ws` and `undici`. With Renovate's cooldown working again that stops being the only line of defence, but the exclusion is still broader than the CVE case its comment describes. Tracked in #1140; deliberately left out of this PR.