### PR TITLE
fix(renovate): drop two words cspell rejects from a rule description

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -75,7 +75,7 @@
       "groupName": null
     },
     {
-      "description": "Core frameworks, major only: high-risk means a human decides. It used to apply to every update type, which made patch releases of the fastest-moving packages here permanently un-approvable by dep-triage and left them stacking up unread. Individual review is what groupName: null buys; high-risk is a stronger claim and belongs where behaviour actually changes.",
+      "description": "Core frameworks, major only: high-risk means a human decides. It used to cover every update type, which left patch releases of the fastest-moving packages here permanently blocked for dep-triage and stacking up unread. Individual review is what groupName: null buys; high-risk is a stronger claim and belongs where behavior actually changes.",
       "matchPackageNames": [
         "next",
         "react",


### PR DESCRIPTION
## Current State

`cspell-check` is red on `develop` and on every PR based on it since #1147 merged — **#1138, #1142, #1146 and #1148**. Four PRs, one cause, and the cause is mine.

```
renovate.json:78:201 - Unknown word (approvable)
renovate.json:78:356 - Unknown word (behaviour)
CSpell: Files checked: 511, Issues found: 2 in 1 file.
```

Both words are in the `packageRules` description I added in #1147. `approvable` is a coinage. `behaviour` is the British spelling in a repository that uses `behavior` everywhere else — five occurrences to one, and the one was mine.

`cspell.json` scans `**/*.{ts,tsx,js,jsx,md,json}`, so a prose description inside `renovate.json` is spell-checked exactly like source. `.agent/skills/dep-triage/SKILL.md` was not affected: it sits under a dot-directory, which the glob does not reach, which is why the same wording there passed and I did not catch this before merging.

## Problem

Four PRs cannot go green, including the release PR #1146 and a security PR #1142, for a reason unrelated to any of them. It is also the kind of failure that reads as a mystery from the PR page — the check fails on a file none of those PRs touch.

## Changes

The description is reworded to say the same thing without either word. Nothing else moves: the two core-framework rules from #1147 and the `major`-only `high-risk` scope are byte-for-byte unchanged, as are all match conditions and labels.

**Not** added to `.cspell/project-words.txt`, deliberately. Neither word is a term this project needs, and widening the dictionary to make a check pass is the wrong direction for a checker whose value is that it stays narrow. The skill's own rule against weakening a check to get green applies to me as much as to a dependency PR.

## Impact

Unblocks `cspell-check` on `develop` and on the four PRs above. No behavior change in Renovate: `renovate-config-validator` exits 0 and the rule set is identical.

Verified by exit code, reproducing the way CI does it (`pnpm cspell` → `cspell lint .`):

| | before | after |
|---|---|---|
| `cspell@9.8.0 lint .` | **exit 1**, 2 issues in 1 file | **exit 0**, 0 issues, same 511 files |
| `renovate-config-validator` | exit 0 | exit 0 |

Worth merging ahead of the others, since the four red PRs stay red until it lands.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EFbRs8RskmYDeKGsjm1fV

---
_Generated by [Claude Code](https://claude.ai/code/session_011EFbRs8RskmYDeKGsjm1fV)_