### PR TITLE
fix(dep-triage): approve mechanical repairs in the same run and escalate with a label

### DIFF
--- a/.agent/skills/dep-triage/SKILL.md
+++ b/.agent/skills/dep-triage/SKILL.md
@@ -289,8 +289,10 @@ rather than writing one by hand.
 ## Step 6: Report
 
 Post one summary comment for the whole run on the run-log issue
-(`dep-triage run log`, vspo-lab/vspo-portal#1151; recreate it with that title if
-it has been closed). Cover: which GitHub tools the run had, approved (with the
+(`dep-triage run log`, vspo-lab/vspo-portal#1151). If it has been closed, an
+`apply` run recreates it with that title; a `report` run creates no issues, so
+it comments on the closed issue when that is possible and otherwise states in
+its output that an `apply` run must recreate the log. Cover: which GitHub tools the run had, approved (with the
 one-line reason), merged, repaired or re-run, escalated (PR link plus reason),
 security findings and their outcome, and anything the maintainer must do. One
 comment per run, never one per PR, and never edit an earlier run's comment. A

--- a/.agent/skills/dep-triage/SKILL.md
+++ b/.agent/skills/dep-triage/SKILL.md
@@ -109,10 +109,15 @@ it. The version-move condition is what separates the two.
 ### What you do not approve
 
 - Anything labelled `major` or `high-risk`. `high-risk` marks a major of a core
-  framework, so both mean the same thing: behaviour can change. Report them and
-  let the maintainer decide
-- Anything you repaired in this same run. A diff you wrote is not a diff you
-  reviewed independently
+  framework, so both mean the same thing: behaviour can change. Escalate them
+  (below) so the maintainer decides with the release notes in front of them
+- A repair that touched anything beyond a manifest or the lockfile, in the run
+  that wrote it. A merge of `develop`, a lockfile regeneration or a re-run leaves
+  the PR's diff against `develop` exactly what Renovate proposed, so review that
+  diff (`git diff origin/develop...HEAD --stat` must list only manifests and
+  `pnpm-lock.yaml`) and approve in the same run once the checks on the new head
+  are green. A repair that changed application source, tests or config waits
+  for the next run, which reviews it fresh
 - Anything you do not understand. A green check suite is a necessary condition,
   never a sufficient one, and never a substitute for reading the change
 
@@ -130,8 +135,37 @@ it. The version-move condition is what separates the two.
 If a check fails identically on the base branch, that is a base-branch defect.
 Escalate it; it is not a licence to merge past a red check.
 
-Everything left unapproved is reported in Step 6 with the reason, so the
-maintainer sees exactly what is waiting and why.
+### After approving
+
+Approval alone does not merge. `dep-auto-merge.yaml` runs on the review event
+and every 15 minutes, but do not leave the outcome to the schedule: dispatch the
+workflow (`workflow_dispatch` on `dep-auto-merge.yaml`, ref `develop`), wait for
+the run to finish, then re-run the evaluator and confirm the PR is gone or
+`MERGE`. A PR that is approved, green and still open at the end of the run is a
+finding to report, not a normal state.
+
+Everything left unapproved is either escalated (below) or reported in Step 6
+with the reason, so the maintainer sees exactly what is waiting and why.
+
+### Escalating to the maintainer
+
+Some PRs are not yours to decide: a `major`, anything labelled `high-risk`, a
+failure that needs an application change, or a third repair attempt. Do not
+leave those as a line in the report. Escalate each one exactly once:
+
+- Post **one comment on the PR, in English**, stating: which check fails and
+  the reproduced error, what you tried, the release-notes assessment (breaking
+  changes relevant to how the package is used here, quoted, not paraphrased into
+  "may have changes"), the security context if the PR is a vulnerability fix,
+  and the concrete decision the maintainer has to make
+- Add the label `awaiting-maintainer-review`. Create it if it is missing
+- Do not comment again on later runs while the label is present and the head
+  commit is unchanged. A new head (Renovate rebase, a maintainer push) means a
+  fresh evaluation: re-run the checks above, and remove the label only when the
+  PR has become approvable under Step 2a
+
+The label is a signal to a person, never an input to the merge gate. Nothing in
+`scripts/dep-triage-report.py` reads it.
 
 ## Step 2: Repair failures
 
@@ -188,11 +222,26 @@ against a cached older Renovate.
 
 Verify locally with `./scripts/post-edit-check.sh` for `vspo-portal`, or
 `scripts/check-preset-references.sh` plus `renovate-config-validator` for
-`config`, before pushing. Do not wait for CI afterwards: the PR is re-evaluated
-against Step 2a on the next run, once the checks have settled.
+`config`, before pushing. Then wait for the checks on the new head and finish
+Step 2a in the same run, as described under "After a repair push" below.
 
-Cap repairs at **two attempts per PR**. On a third failure, stop, label the PR
-`needs-human`, and escalate.
+Cap repairs at **two attempts per PR**. On a third failure, stop and escalate as
+described in Step 2a: one comment, and the label `awaiting-maintainer-review`.
+
+### After a repair push
+
+The first commit from a non-Renovate author makes Renovate stop rebasing the
+branch ("Edited/Blocked"). From then on the branch is yours to keep mergeable:
+
+- Wait for the checks on the new head to finish (poll the check runs, up to 20
+  minutes) and continue with Step 2a in the **same run**. A repaired PR left for
+  the next day sits green and unmerged while `develop` moves on, which is how
+  #1138 and #1148 stalled
+- When the branch falls behind `develop` and a check depends on state that
+  `develop` has since fixed, merge `develop` into the branch. Never rebase or
+  force-push a Renovate branch
+- If the repair leaves the diff against `develop` wider than manifests plus
+  lockfile, say so in the report; the next run reviews it
 
 ## Step 3: Security triage
 
@@ -239,8 +288,13 @@ rather than writing one by hand.
 
 ## Step 6: Report
 
-Post one summary comment for the whole run covering merged, repaired, escalated,
-suppressed, and awaiting-human items. One comment per run, never one per PR.
+Post one summary comment for the whole run on the run-log issue
+(`dep-triage run log`, vspo-lab/vspo-portal#1151; recreate it with that title if
+it has been closed). Cover: which GitHub tools the run had, approved (with the
+one-line reason), merged, repaired or re-run, escalated (PR link plus reason),
+security findings and their outcome, and anything the maintainer must do. One
+comment per run, never one per PR, and never edit an earlier run's comment. A
+run with nothing to do posts one sentence.
 
 # Permission Boundary
 
@@ -254,11 +308,17 @@ Allowed:
 - Push repair commits to `renovate/**` branches
 - Edit `.trivyignore.yaml`, `pnpm.overrides`, `docs/security/dependency-policy.md`
 - Create or update the `develop -> main` PR, open issues, comment
+- Add or remove `awaiting-maintainer-review`, and post the escalation comment
+  that goes with it
+- Dispatch `dep-auto-merge.yaml` after approving, so the merge happens in this
+  run rather than on the next schedule tick
 
 Never:
 
-- Merge any pull request. That is the workflow's job, not yours
-- Approve without reading the diff, or approve a PR you repaired in this run
+- Merge any pull request directly. That is the workflow's job, not yours; you
+  may only dispatch it
+- Approve without reading the diff, or approve, in the same run, a repair that
+  changed anything beyond manifests and `pnpm-lock.yaml`
 - Approve anything labelled `major` or `high-risk`
 - Re-run a failed job without first reading the log and establishing an external
   cause

--- a/docs/infra/dependency-auto-flow.md
+++ b/docs/infra/dependency-auto-flow.md
@@ -83,7 +83,8 @@ approval is what makes a merge deliberate.
 The approval comes from the maintainer, or from the daily `dep-triage` run acting
 on their behalf after reading the diff. What that run may and may not approve is
 set out in `.agent/skills/dep-triage/SKILL.md`; in short, it never approves a
-`major`, anything labelled `high-risk`, or a branch it repaired itself.
+`major`, anything labelled `high-risk`, or, in the same run, a repair that
+changed more than the manifests and the lockfile.
 
 - An approval on a superseded commit is stale: the approver never saw what would
   actually be merged
@@ -196,10 +197,21 @@ can also be run by hand with `/dep-triage`.
 
 Steps: collect open dependency PRs, repair red CI, triage security findings, prune
 stale `pnpm.overrides` pins, refresh the release PR, and post one summary comment
-per run.
+per run on the `dep-triage run log` issue (#1151), so every run is auditable
+without opening the routine's session.
 
-Repairs are capped at two attempts per PR; a third failure is escalated and the PR
-is labelled `needs-human`.
+Repairs are capped at two attempts per PR. Anything the routine may not decide
+(a `major`, a `high-risk` update, a failure that needs an application change, a
+third repair attempt) is escalated once: an English comment on the PR with the
+reproduced failure, the release-notes assessment and the decision required, plus
+the label `awaiting-maintainer-review`. The label is for a person; the merge gate
+does not read it.
+
+After a repair push Renovate stops rebasing the branch, so the routine keeps it
+mergeable itself: it waits for the checks on the new head and approves in the
+same run when the diff against `develop` is still only manifests plus lockfile,
+and merges `develop` in when the branch falls behind. Leaving a repaired PR to
+the next day is what left #1138 and #1148 green and unmerged.
 
 ### Permission boundary
 
@@ -212,8 +224,10 @@ It may not merge anything, or edit labels to change a gate's outcome. Merging
 belongs to `dep-auto-merge.yaml`.
 
 Approval is bounded rather than open: never a `major`, never anything labelled
-`high-risk`, and never a branch the same run repaired, since a diff the routine
-wrote is not a diff it reviewed. The full conditions are in
+`high-risk`, and never, in the same run, a repair that changed application
+source, tests or config, since a diff the routine wrote is not a diff it
+reviewed. A merge of `develop` or a lockfile regeneration leaves Renovate's diff
+intact and may be approved once its checks are green. The full conditions are in
 `.agent/skills/dep-triage/SKILL.md`, which is the operative text; this is a
 summary of it.
 

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -14,7 +14,7 @@ over time.
 | Who may merge | `dep-auto-merge.yaml` only. Renovate automerge is disabled everywhere |
 | Who may approve | The maintainer, or the `dep-triage` skill acting on their behalf, having read the diff |
 | Merge without review | Never. There is no approval-free path |
-| Never auto-approved | `major`, `high-risk`, and anything the triage run repaired itself |
+| Never auto-approved | `major`, `high-risk`, and (in the same run) a repair that changed more than manifests and the lockfile |
 | Blocking scan | Trivy, production dependencies only, CRITICAL and HIGH |
 | Non-blocking scan | Trivy with `--include-dev-deps`, report only |
 | Suppression | Requires `statement` and `expired_at`, maximum 90 days |
@@ -102,6 +102,21 @@ Format:
 - Evidence: what was checked, such as a search for the vulnerable API
 - Follow-up: expiry date, or the issue tracking the fix
 ```
+
+### 2026-09-05 CVE-2026-73422 astro
+
+- Outcome: `[ESCALATE]`
+- Reason: The fix is `astro@7.1.0`, a major. `service/bot-dashboard` also needs
+  `@astrojs/cloudflare` 14 and `@astrojs/react` 6 (and the `wrangler` catalog at
+  `^4.125.0`) before `astro build` succeeds on Astro 7, so this is a migration,
+  not a repair. The vulnerable path (attacker-controlled View Transition
+  animation properties) is not reachable: the service uses `ClientRouter` only,
+  with no `transition:animate` and no request-derived animation values.
+- Evidence: `pnpm build` on `renovate/npm-astro-vulnerability` fails in the
+  Cloudflare adapter's build runner (`Missing field moduleType`); search of
+  `service/bot-dashboard/src` for `transition:animate` and `astro:transitions`.
+- Follow-up: #1152 tracks the migration; #1142 is labelled
+  `awaiting-maintainer-review`.
 
 ### 2026-08-14 Migration from .trivyignore
 

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -105,7 +105,7 @@ Format:
 
 ### 2026-09-05 CVE-2026-73422 astro
 
-- Outcome: `[ESCALATE]`
+- Outcome: [ESCALATE]
 - Reason: The fix is `astro@7.1.0`, a major. `service/bot-dashboard` also needs
   `@astrojs/cloudflare` 14 and `@astrojs/react` 6 (and the `wrangler` catalog at
   `^4.125.0`) before `astro build` succeeds on Astro 7, so this is a migration,


### PR DESCRIPTION
## Current State
The dep-triage routine repaired #1138 and #1148 by merging `develop` in, then could not approve them because `SKILL.md` forbade approving any branch the same run had repaired. Renovate stops rebasing after a foreign commit, so both PRs sat 18/18 green and unmerged until a person approved them. Escalations pointed at a `needs-human` label that does not exist in this repository, and run summaries were never posted anywhere.

## Problem
Every repaired PR deadlocks, escalations silently fail to label, and there is no audit trail of what the routine did on a given day.

## Changes
- `.agent/skills/dep-triage/SKILL.md`: a repair that leaves the diff against `develop` at manifests plus lockfile is approvable once its checks are green; repairs touching source, tests or config wait for the next run. Escalations post one English comment per head commit and add `awaiting-maintainer-review` (label created). Approvals are followed by a `dep-auto-merge.yaml` dispatch and a merge confirmation. Run summaries go to the run-log issue #1151.
- `docs/infra/dependency-auto-flow.md`, `docs/security/dependency-policy.md`: mirror the rule change, and record the CVE-2026-73422 astro escalation (#1142 / #1152) in the decision log.

## Impact
Docs and skill text only. The routine already runs with these rules in its prompt; this makes the repository copy the source of truth again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8P78E9M9U45hZ7bfKwkye

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8P78E9M9U45hZ7bfKwkye)_