### PR TITLE
test(bot-dashboard): add Playwright E2E covering every screen and feature

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -226,9 +226,34 @@ jobs:
           flags: bot-dashboard
           fail_ci_if_error: false
 
+  e2e-bot-dashboard:
+    needs: changes
+    if: needs.changes.outputs['bot-dashboard'] == 'true' || needs.changes.outputs.packages == 'true' || needs.changes.outputs.deps == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup PNPM
+        uses: ./.github/actions/setup-pnpm
+        with:
+          build: 'false'
+      - name: Build package dependencies
+        run: pnpm --filter "@vspo-lab/*" build
+      - name: Install Playwright browser
+        run: pnpm --filter bot-dashboard exec playwright install --with-deps chromium
+      - name: Run Playwright
+        run: pnpm --filter bot-dashboard test:e2e
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-bot-dashboard
+          path: service/bot-dashboard/playwright-report
+          retention-days: 7
+
   # Post a summary comment on the PR with all check results
   pr-summary:
-    needs: [changes, biome-check, typescript-check, knip-check, textlint-check, markdownlint-check, cspell-check, bundle-size, test]
+    needs: [changes, biome-check, typescript-check, knip-check, textlint-check, markdownlint-check, cspell-check, bundle-size, test, e2e-bot-dashboard]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -244,6 +269,7 @@ jobs:
           CSPELL: ${{ needs.cspell-check.result }}
           BUNDLE: ${{ needs.bundle-size.result }}
           TEST: ${{ needs.test.result }}
+          E2E_BOT: ${{ needs.e2e-bot-dashboard.result }}
           WEB_SUMMARY: ${{ needs.test.outputs.web-summary }}
           BOT_SUMMARY: ${{ needs.test.outputs.bot-summary }}
         run: |
@@ -270,6 +296,7 @@ jobs:
             echo "| CSpell | $(icon "$CSPELL") ${CSPELL} |"
             echo "| Bundle Size | $(icon "$BUNDLE") ${BUNDLE} |"
             echo "| Tests | $(icon "$TEST") ${TEST} |"
+            echo "| E2E (bot-dashboard) | $(icon "$E2E_BOT") ${E2E_BOT} |"
             echo ""
 
             if [ -n "$WEB_SUMMARY" ] || [ -n "$BOT_SUMMARY" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ docs/plan/
 
 # testing
 **/coverage
+**/test-results
+**/playwright-report
+**/blob-report
 
 # next.js
 **/.next/

--- a/biome.json
+++ b/biome.json
@@ -14,6 +14,8 @@
       "!**/.wrangler/**/*",
       "!**/public/**/*",
       "!**/dist/**/*",
+      "!**/test-results/**/*",
+      "!**/playwright-report/**/*",
       "!**/build/**/*",
       "!**/tools/**/*",
       "!**/*.config.js",

--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -1,6 +1,6 @@
 # E2E Testing Implementation Guidelines
 
-> **Status:** Not yet implemented. Playwright is not installed. This document describes the target architecture.
+> **Status:** Implemented for `service/bot-dashboard` (Playwright). `service/vspo-schedule/v2/web` is not yet covered.
 
 ## Purpose
 
@@ -68,11 +68,40 @@ test("Entire item creation flow", async ({ page }) => {
 - Write test names as business scenarios (e.g., "A new order can be created")
 - Maintain a lean set of key scenarios and complement coverage with Unit/Integration/API tests
 
-## Recommended File Structure
+## bot-dashboard
 
-- `service/vspo-schedule/v2/web/e2e/auth.setup.ts`
-- `service/vspo-schedule/v2/web/e2e/*.spec.ts`
-- `service/vspo-schedule/v2/web/playwright.config.ts`
+### Layout
+
+- `service/bot-dashboard/playwright.config.ts` - config, including the `webServer` that boots `astro dev`
+- `service/bot-dashboard/astro.config.e2e.ts` - the app config with the dev toolbar disabled
+- `service/bot-dashboard/e2e/helpers.ts` - guild ids, island hydration wait, shared locators
+- `service/bot-dashboard/e2e/*.spec.ts` - one file per screen or concern: `landing`, `auth`, `dashboard`, `guild-channels`, `announcements`, `api`
+
+### Running
+
+```bash
+cd service/bot-dashboard
+pnpm exec playwright install chromium   # once
+pnpm test:e2e
+pnpm test:e2e:ui                        # interactive
+```
+
+`pnpm test:e2e` starts the dev server on port 4341 by itself. Locally it reuses a server that is already listening there; in CI (`CI=1`) it always starts a fresh one. `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` points the run at a preinstalled Chromium when the browser download is unavailable.
+
+### Where the external boundary is
+
+The dashboard has two external dependencies: Discord OAuth and the `APP_WORKER` service binding (the `vspo-portal-app` Worker, which lives in another repository). Both are replaced by the dev mock the app already ships (`src/features/shared/dev-mock.ts`, active when `astro dev` runs with `DEV_MOCK_AUTH=true`). Everything in this repository runs for real: Astro pages, middleware, session storage, Astro Actions, API routes, React islands.
+
+Consequences to keep in mind:
+
+- The mock user is always logged in, so the landing page is reached with `/?preview` and the OAuth flow is exercised at the HTTP level (`/auth/discord` redirect, `/auth/callback` state and code handling) rather than by following Discord's redirect.
+- The mock middleware skips the guild-admin guard and token refresh, so those branches are not covered here. They are the middleware's job and belong in unit tests.
+- Channel mutations are persisted in a process-wide in-memory store inside the dev mock. Tests therefore run with one worker, and every mutation test restores the seed state it changed.
+- `storageState` is deliberately not used: sessions are server-side, so sharing a cookie between tests would leak the locale one test set into the next. Each test gets a fresh context and therefore a fresh session.
+
+### CI
+
+`.github/workflows/pr-check.yaml` runs the suite in the `e2e-bot-dashboard` job whenever `service/bot-dashboard/**`, `packages/**` or the root manifests change. The HTML report is uploaded as an artifact on failure, and the result appears in the PR Check Summary comment.
 
 ## References (Primary Sources)
 

--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -86,7 +86,7 @@ pnpm test:e2e
 pnpm test:e2e:ui                        # interactive
 ```
 
-`pnpm test:e2e` starts the dev server on port 4341 by itself. Locally it reuses a server that is already listening there; in CI (`CI=1`) it always starts a fresh one. `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` points the run at a preinstalled Chromium when the browser download is unavailable.
+`pnpm test:e2e` starts the dev server on port 4341 by itself. A server that is already listening there is reused only with `PLAYWRIGHT_REUSE_SERVER=1`, because its in-memory channel store may have drifted from the seed. `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` points the run at a preinstalled Chromium when the browser download is unavailable.
 
 ### Where the external boundary is
 
@@ -96,7 +96,7 @@ Consequences to keep in mind:
 
 - The mock user is always logged in, so the landing page is reached with `/?preview` and the OAuth flow is exercised at the HTTP level (`/auth/discord` redirect, `/auth/callback` state and code handling) rather than by following Discord's redirect.
 - The mock middleware skips the guild-admin guard and token refresh, so those branches are not covered here. They are the middleware's job and belong in unit tests.
-- Channel mutations are persisted in a process-wide in-memory store inside the dev mock. Tests therefore run with one worker, and every mutation test restores the seed state it changed.
+- Channel mutations are persisted in a process-wide in-memory store inside the dev mock, and only while `astro dev` runs with the mock enabled; without the mock, mutations still fail when `APP_WORKER` is unavailable. Tests therefore run with one worker, and every mutation test arranges the state it needs and restores the seed before it ends, so a single test can be run with `--grep`.
 - `storageState` is deliberately not used: sessions are server-side, so sharing a cookie between tests would leak the locale one test set into the next. Each test gets a fresh context and therefore a fresh session.
 
 ### CI

--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -16,7 +16,7 @@
 
 1. Use Playwright Locators and Web-first assertions
 2. Keep tests mutually independent (no shared state)
-3. Reuse authentication via `storageState` and avoid duplicating login operations
+3. Reuse authentication via `storageState` when the session lives in the browser (cookies, storage); apps with server-side sessions, such as bot-dashboard, mock the login at the boundary instead
 4. Prepare test data via API to minimize UI operation prerequisites
 
 ## Mocking Policy

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 4.20260702.1
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@storybook/html-vite':
         specifier: ^10.5.7
         version: 10.5.7(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.2)(yaml@2.9.0))(webpack@5.109.2(esbuild@0.28.1)(lightningcss@1.33.0))
@@ -281,19 +284,19 @@ importers:
         version: 7.3.11(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@mui/material-nextjs':
         specifier: ^7.3.10
-        version: 7.3.10(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 7.3.10(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@mui/system':
         specifier: ^7.3.11
         version: 7.3.11(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(react@19.2.8)
       '@next/third-parties':
         specifier: ~16.2.12
-        version: 16.2.12(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 16.2.12(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@opennextjs/cloudflare':
         specifier: ^1.20.2
-        version: 1.20.2(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(wrangler@4.127.1(@cloudflare/workers-types@4.20260702.1))
+        version: 1.20.2(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(wrangler@4.127.1(@cloudflare/workers-types@4.20260702.1))
       '@serwist/next':
         specifier: ^9.5.12
-        version: 9.5.12(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(webpack@5.109.2(lightningcss@1.33.0)(postcss@8.5.23))
+        version: 9.5.12(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(webpack@5.109.2(lightningcss@1.33.0)(postcss@8.5.23))
       '@vspo-lab/api':
         specifier: workspace:^
         version: link:../../../../packages/api
@@ -311,10 +314,10 @@ importers:
         version: 3.2.0(date-fns@4.4.0)
       next:
         specifier: 'catalog:'
-        version: 16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl:
         specifier: ^4.13.5
-        version: 4.13.5(@swc/helpers@0.5.23)(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
+        version: 4.13.5(@swc/helpers@0.5.23)(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -357,7 +360,7 @@ importers:
         version: 4.20260702.1
       '@storybook/nextjs':
         specifier: ^10.5.7
-        version: 10.5.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(lightningcss@1.33.0)(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(type-fest@4.41.0)(typescript@6.0.3)(webpack-hot-middleware@2.26.1)(webpack@5.109.2(lightningcss@1.33.0)(postcss@8.5.23))
+        version: 10.5.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(lightningcss@1.33.0)(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(type-fest@4.41.0)(typescript@6.0.3)(webpack-hot-middleware@2.26.1)(webpack@5.109.2(lightningcss@1.33.0)(postcss@8.5.23))
       '@storybook/react':
         specifier: ^10.5.7
         version: 10.5.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(typescript@6.0.3)
@@ -3749,6 +3752,11 @@ packages:
     resolution: {integrity: sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==}
     engines: {node: '>= 10.0.0'}
 
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17':
     resolution: {integrity: sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==}
     engines: {node: '>= 10.13'}
@@ -6483,6 +6491,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -8247,6 +8260,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   pluralize@2.0.0:
     resolution: {integrity: sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==}
@@ -13054,11 +13077,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@mui/material-nextjs@7.3.10(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@mui/material-nextjs@7.3.10(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.18)(react@19.2.8))(@types/react@19.2.18)(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@emotion/react': 11.14.0(@types/react@19.2.18)(react@19.2.8)
-      next: 16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
     optionalDependencies:
       '@emotion/cache': 11.14.0
@@ -13203,9 +13226,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.3.3':
     optional: true
 
-  '@next/third-parties@16.2.12(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@next/third-parties@16.2.12(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
-      next: 16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       third-party-capital: 1.0.20
 
@@ -13244,7 +13267,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opennextjs/aws@4.1.0(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@opennextjs/aws@4.1.0(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@aws-sdk/client-cloudfront': 3.984.0
@@ -13260,24 +13283,24 @@ snapshots:
       cookie: 1.1.1
       esbuild: 0.25.4
       express: 5.2.1
-      next: 16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       path-to-regexp: 6.3.0
       urlpattern-polyfill: 10.1.0
       yaml: 2.9.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opennextjs/cloudflare@1.20.2(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(wrangler@4.127.1(@cloudflare/workers-types@4.20260702.1))':
+  '@opennextjs/cloudflare@1.20.2(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(wrangler@4.127.1(@cloudflare/workers-types@4.20260702.1))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 4.1.0(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+      '@opennextjs/aws': 4.1.0(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       ci-info: 4.4.0
       cloudflare: 4.5.0
       comment-json: 4.6.2
       enquirer: 2.4.1
       glob: 12.0.0
-      next: 16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       ts-tqdm: 0.8.6
       wrangler: 4.127.1(@cloudflare/workers-types@4.20260702.1)
       yargs: 18.1.0
@@ -13656,6 +13679,10 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.6.0
       '@parcel/watcher-win32-x64': 2.6.0
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.109.2(lightningcss@1.33.0)(postcss@8.5.23))':
     dependencies:
       ansi-html: 0.0.9
@@ -13858,7 +13885,7 @@ snapshots:
     transitivePeerDependencies:
       - browserslist
 
-  '@serwist/next@9.5.12(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(webpack@5.109.2(lightningcss@1.33.0)(postcss@8.5.23))':
+  '@serwist/next@9.5.12(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@6.0.3)(webpack@5.109.2(lightningcss@1.33.0)(postcss@8.5.23))':
     dependencies:
       '@serwist/build': 9.5.12(browserslist@4.28.7)(typescript@6.0.3)
       '@serwist/utils': 9.5.12(browserslist@4.28.7)
@@ -13867,7 +13894,7 @@ snapshots:
       browserslist: 4.28.7
       glob: 13.0.6
       kolorist: 1.8.0
-      next: 16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       semver: 7.8.5
       serwist: 9.5.12(browserslist@4.28.7)(typescript@6.0.3)
@@ -14253,7 +14280,7 @@ snapshots:
       '@vitest/utils': 2.1.9
       storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
 
-  '@storybook/nextjs@10.5.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(lightningcss@1.33.0)(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(type-fest@4.41.0)(typescript@6.0.3)(webpack-hot-middleware@2.26.1)(webpack@5.109.2(lightningcss@1.33.0)(postcss@8.5.23))':
+  '@storybook/nextjs@10.5.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(lightningcss@1.33.0)(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(type-fest@4.41.0)(typescript@6.0.3)(webpack-hot-middleware@2.26.1)(webpack@5.109.2(lightningcss@1.33.0)(postcss@8.5.23))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7)
@@ -14277,7 +14304,7 @@ snapshots:
       css-loader: 6.11.0(webpack@5.109.2(lightningcss@1.33.0)(postcss@8.5.23))
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.109.2(lightningcss@1.33.0)(postcss@8.5.23))
       postcss: 8.5.23
       postcss-loader: 8.2.1(postcss@8.5.23)(typescript@6.0.3)(webpack@5.109.2(lightningcss@1.33.0)(postcss@8.5.23))
@@ -16902,6 +16929,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -18567,14 +18597,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.5: {}
 
-  next-intl@4.13.5(@swc/helpers@0.5.23)(next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@6.0.3):
+  next-intl@4.13.5(@swc/helpers@0.5.23)(next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@6.0.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.13
       '@parcel/watcher': 2.6.0
       '@swc/core': 1.15.47(@swc/helpers@0.5.23)
       icu-minify: 4.13.5
       negotiator: 1.0.0
-      next: 16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl-swc-plugin-extractor: 4.13.5
       po-parser: 2.1.1
       react: 19.2.8
@@ -18584,7 +18614,7 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  next@16.3.3(@babel/core@7.29.7)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.3.3(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.3.3
       '@swc/helpers': 0.5.23
@@ -18603,6 +18633,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.3.3
       '@next/swc-win32-arm64-msvc': 16.3.3
       '@next/swc-win32-x64-msvc': 16.3.3
+      '@playwright/test': 1.62.1
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.35.4(@types/node@25.9.5)
     transitivePeerDependencies:
@@ -19053,6 +19084,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@2.0.0: {}
 

--- a/service/bot-dashboard/astro.config.e2e.ts
+++ b/service/bot-dashboard/astro.config.e2e.ts
@@ -1,0 +1,4 @@
+import base from "./astro.config";
+
+// The dev toolbar overlays the bottom of the viewport and would swallow clicks in E2E.
+export default { ...base, devToolbar: { enabled: false } };

--- a/service/bot-dashboard/e2e/announcements.spec.ts
+++ b/service/bot-dashboard/e2e/announcements.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+import { DEV_GUILD_ID, switchLanguage } from "./helpers";
+
+test.describe("お知らせ", () => {
+  test("お知らせ一覧が種類・日付・本文付きで表示される", async ({ page }) => {
+    await page.goto("/dashboard/announcements");
+    await expect(
+      page.getByRole("heading", { level: 1, name: "お知らせ" }),
+    ).toBeVisible();
+
+    const article = page.getByRole("article").first();
+    await expect(
+      article.getByText("アップデート", { exact: true }),
+    ).toBeVisible();
+    await expect(article.getByText("2026年4月1日")).toBeVisible();
+    await expect(
+      article.getByRole("heading", {
+        name: "Webダッシュボードをリリースしました",
+      }),
+    ).toBeVisible();
+    await expect(article).toContainText(
+      "ブラウザからBot設定を管理できるようになりました",
+    );
+
+    const nav = page.getByRole("navigation", {
+      name: "サーバーナビゲーション",
+    });
+    await expect(nav.getByRole("link", { name: "お知らせ" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  test("サーバー配下のお知らせはサイドバーにサーバー名を表示する", async ({
+    page,
+  }) => {
+    await page.goto(`/dashboard/${DEV_GUILD_ID}/announcements`);
+    await expect(
+      page.getByRole("heading", { level: 1, name: "お知らせ" }),
+    ).toBeVisible();
+    await expect(
+      page.locator("aside").getByRole("heading", { name: "Dev Server 1" }),
+    ).toBeVisible();
+
+    const nav = page.getByRole("navigation", {
+      name: "サーバーナビゲーション",
+    });
+    await expect(
+      nav.getByRole("link", { name: "チャンネル設定" }),
+    ).toHaveAttribute("href", `/dashboard/${DEV_GUILD_ID}`);
+    await expect(nav.getByRole("link", { name: "お知らせ" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  test("英語ではお知らせも英語で表示される", async ({ page }) => {
+    await page.goto("/dashboard/announcements");
+    await switchLanguage(page, "English");
+
+    const article = page.getByRole("article").first();
+    await expect(article.getByText("Update", { exact: true })).toBeVisible();
+    await expect(article.getByText("April 1, 2026")).toBeVisible();
+    await expect(
+      article.getByRole("heading", { name: "Web Dashboard Released" }),
+    ).toBeVisible();
+  });
+});

--- a/service/bot-dashboard/e2e/api.spec.ts
+++ b/service/bot-dashboard/e2e/api.spec.ts
@@ -10,10 +10,17 @@ test.describe("API ルート", () => {
   }) => {
     const response = await request.get(`/api/guilds/${DEV_GUILD_ID}/channels`);
     expect(response.status()).toBe(200);
-    const channels = (await response.json()) as { id: string; name: string }[];
+    const channels: unknown = await response.json();
     expect(channels).toHaveLength(6);
-    expect(channels.map((ch) => ch.name)).toEqual(
-      expect.arrayContaining(["vspo-notifications", "general", "random"]),
+    expect(channels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "100000000000000001",
+          name: "vspo-notifications",
+        }),
+        expect.objectContaining({ id: "100000000000000005", name: "general" }),
+        expect.objectContaining({ id: "100000000000000006", name: "random" }),
+      ]),
     );
   });
 

--- a/service/bot-dashboard/e2e/api.spec.ts
+++ b/service/bot-dashboard/e2e/api.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "@playwright/test";
+import { DEV_GUILD_ID, ORIGIN, OTHER_GUILD_ID } from "./helpers";
+
+// Astro's `security.checkOrigin` rejects form posts without a same-origin Origin header.
+const sameOrigin = { origin: ORIGIN };
+
+test.describe("API ルート", () => {
+  test("GET /api/guilds/:guildId/channels はテキストチャンネル一覧を返す", async ({
+    request,
+  }) => {
+    const response = await request.get(`/api/guilds/${DEV_GUILD_ID}/channels`);
+    expect(response.status()).toBe(200);
+    const channels = (await response.json()) as { id: string; name: string }[];
+    expect(channels).toHaveLength(6);
+    expect(channels.map((ch) => ch.name)).toEqual(
+      expect.arrayContaining(["vspo-notifications", "general", "random"]),
+    );
+  });
+
+  test("Bot 未導入サーバーのチャンネル一覧は空配列", async ({ request }) => {
+    const response = await request.get(
+      `/api/guilds/${OTHER_GUILD_ID}/channels`,
+    );
+    expect(response.status()).toBe(200);
+    expect(await response.json()).toEqual([]);
+  });
+
+  test("Snowflake でない guildId は 400", async ({ request }) => {
+    const response = await request.get("/api/guilds/not-a-guild/channels");
+    expect(response.status()).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid guildId" });
+  });
+
+  test("Origin ヘッダーの無いフォーム送信は CSRF 対策で拒否される", async ({
+    request,
+  }) => {
+    const response = await request.post("/api/change-locale", {
+      form: { locale: "en" },
+      maxRedirects: 0,
+    });
+    expect(response.status()).toBe(403);
+  });
+
+  test("POST /api/change-locale は言語を保存して _returnTo に戻る", async ({
+    request,
+  }) => {
+    const response = await request.post("/api/change-locale", {
+      form: { locale: "en", _returnTo: "/dashboard/announcements" },
+      headers: sameOrigin,
+      maxRedirects: 0,
+    });
+    expect(response.status()).toBe(302);
+    expect(response.headers().location).toBe("/dashboard/announcements");
+
+    const page = await request.get("/dashboard");
+    expect(await page.text()).toContain('<html lang="en"');
+  });
+
+  test("外部 URL の _returnTo は無視され Referer に戻る", async ({
+    request,
+  }) => {
+    const response = await request.post("/api/change-locale", {
+      form: { locale: "ja", _returnTo: "https://evil.example/phish" },
+      headers: { ...sameOrigin, referer: `${ORIGIN}/dashboard/announcements` },
+      maxRedirects: 0,
+    });
+    expect(response.headers().location).toBe(
+      `${ORIGIN}/dashboard/announcements`,
+    );
+  });
+
+  test("プロトコル相対 URL の _returnTo も無視され、Referer が無ければトップに戻る", async ({
+    request,
+  }) => {
+    const response = await request.post("/api/change-locale", {
+      form: { locale: "ja", _returnTo: "//evil.example/phish" },
+      headers: sameOrigin,
+      maxRedirects: 0,
+    });
+    expect(response.headers().location).toBe("/");
+  });
+});
+
+test.describe("静的ルートとエラーページ", () => {
+  test("robots.txt はダッシュボード・認証・API をクロール対象外にする", async ({
+    request,
+  }) => {
+    const response = await request.get("/robots.txt");
+    expect(response.status()).toBe(200);
+    expect(response.headers()["content-type"]).toContain("text/plain");
+    expect(await response.text()).toBe(
+      [
+        "User-agent: *",
+        "Allow: /",
+        "Allow: /en/",
+        "Disallow: /dashboard/",
+        "Disallow: /en/dashboard/",
+        "Disallow: /auth/",
+        "Disallow: /en/auth/",
+        "Disallow: /api/",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  test("存在しないページは 404 とホームへの導線を表示する", async ({
+    page,
+  }) => {
+    const response = await page.goto("/this-page-does-not-exist");
+    expect(response?.status()).toBe(404);
+    await expect(
+      page.getByRole("heading", { level: 1, name: "404" }),
+    ).toBeVisible();
+    await expect(page.getByText("ページが見つかりませんでした")).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "ホームに戻る" }),
+    ).toHaveAttribute("href", "/");
+  });
+
+  test("すべてのレスポンスにセキュリティヘッダーが付く", async ({
+    request,
+  }) => {
+    const response = await request.get("/?preview");
+    const headers = response.headers();
+    expect(headers["content-security-policy"]).toContain("default-src 'self'");
+    expect(headers["content-security-policy"]).toContain(
+      "frame-ancestors 'none'",
+    );
+    expect(headers["x-frame-options"]).toBe("DENY");
+    expect(headers["x-content-type-options"]).toBe("nosniff");
+    expect(headers["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+    expect(headers["permissions-policy"]).toContain("camera=()");
+  });
+});

--- a/service/bot-dashboard/e2e/auth.spec.ts
+++ b/service/bot-dashboard/e2e/auth.spec.ts
@@ -1,0 +1,122 @@
+import { type APIRequestContext, expect, test } from "@playwright/test";
+import { ORIGIN, openUserMenu, switchLanguage } from "./helpers";
+
+const DISCORD_AUTHORIZE = "https://discord.com/api/oauth2/authorize";
+
+/** Follows the login redirect only far enough to learn the CSRF state stored in the session. */
+const startLogin = async (request: APIRequestContext): Promise<string> => {
+  const response = await request.get("/auth/discord", { maxRedirects: 0 });
+  expect(response.status()).toBe(302);
+  const location = new URL(response.headers().location);
+  const state = location.searchParams.get("state");
+  expect(state).toBeTruthy();
+  return state as string;
+};
+
+test.describe("Discord ログイン（Discord 側はモック）", () => {
+  test("ログイン導線は PKCE 付きの Discord 認可 URL へリダイレクトする", async ({
+    request,
+  }) => {
+    const response = await request.get("/auth/discord", { maxRedirects: 0 });
+    expect(response.status()).toBe(302);
+
+    const location = new URL(response.headers().location);
+    expect(`${location.origin}${location.pathname}`).toBe(DISCORD_AUTHORIZE);
+    expect(location.searchParams.get("client_id")).toBe("e2e-client-id");
+    expect(location.searchParams.get("redirect_uri")).toBe(
+      `${ORIGIN}/auth/callback`,
+    );
+    expect(location.searchParams.get("response_type")).toBe("code");
+    expect(location.searchParams.get("scope")).toBe("identify guilds");
+    expect(location.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(location.searchParams.get("code_challenge")).toMatch(
+      /^[A-Za-z0-9_-]{43}$/,
+    );
+    expect(location.searchParams.get("state")).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  test("Discord がエラーを返した場合は auth_failed でトップへ戻る", async ({
+    request,
+  }) => {
+    const response = await request.get("/auth/callback?error=access_denied", {
+      maxRedirects: 0,
+    });
+    expect(response.status()).toBe(302);
+    expect(response.headers().location).toBe("/?error=auth_failed");
+  });
+
+  test("state が一致しないコールバックは invalid_state で拒否される", async ({
+    request,
+  }) => {
+    await startLogin(request);
+    const response = await request.get("/auth/callback?state=forged&code=x", {
+      maxRedirects: 0,
+    });
+    expect(response.headers().location).toBe("/?error=invalid_state");
+  });
+
+  test("code の無いコールバックは no_code で戻る", async ({ request }) => {
+    const state = await startLogin(request);
+    const response = await request.get(`/auth/callback?state=${state}`, {
+      maxRedirects: 0,
+    });
+    expect(response.headers().location).toBe("/?error=no_code");
+  });
+
+  test("正しい state と code のコールバックはダッシュボードへ遷移する", async ({
+    request,
+  }) => {
+    const state = await startLogin(request);
+    const response = await request.get(
+      `/auth/callback?state=${state}&code=mock-code`,
+      { maxRedirects: 0 },
+    );
+    expect(response.status()).toBe(302);
+    expect(response.headers().location).toBe("/dashboard");
+  });
+
+  test("使用済みの state は再利用できない", async ({ request }) => {
+    const state = await startLogin(request);
+    await request.get(`/auth/callback?state=${state}&code=mock-code`, {
+      maxRedirects: 0,
+    });
+    const replay = await request.get(
+      `/auth/callback?state=${state}&code=mock-code`,
+      { maxRedirects: 0 },
+    );
+    expect(replay.headers().location).toBe("/?error=invalid_state");
+  });
+});
+
+test.describe("ログアウト", () => {
+  test("ログアウトはセッションを破棄してトップへリダイレクトする", async ({
+    request,
+  }) => {
+    const response = await request.post("/auth/logout", {
+      headers: { origin: ORIGIN },
+      maxRedirects: 0,
+    });
+    expect(response.status()).toBe(302);
+    expect(response.headers().location).toBe("/");
+  });
+
+  test("ユーザーメニューからログアウトすると言語設定などのセッションが消える", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await switchLanguage(page, "English");
+
+    await openUserMenu(page);
+    await page.getByRole("button", { name: "Logout" }).click();
+
+    // The mock middleware logs the user straight back in, so the visible effect
+    // of the destroyed session is the locale falling back to the default.
+    await expect(page).toHaveURL(/\/dashboard$/);
+    await expect(page.locator("html")).toHaveAttribute("lang", "ja");
+    await expect(
+      page.getByRole("heading", { level: 1, name: "サーバー一覧" }),
+    ).toBeVisible();
+  });
+});

--- a/service/bot-dashboard/e2e/auth.spec.ts
+++ b/service/bot-dashboard/e2e/auth.spec.ts
@@ -9,8 +9,10 @@ const startLogin = async (request: APIRequestContext): Promise<string> => {
   expect(response.status()).toBe(302);
   const location = new URL(response.headers().location);
   const state = location.searchParams.get("state");
-  expect(state).toBeTruthy();
-  return state as string;
+  if (state === null) {
+    throw new Error("Discord redirect has no state parameter");
+  }
+  return state;
 };
 
 test.describe("Discord ログイン（Discord 側はモック）", () => {

--- a/service/bot-dashboard/e2e/dashboard.spec.ts
+++ b/service/bot-dashboard/e2e/dashboard.spec.ts
@@ -1,0 +1,202 @@
+import { expect, test } from "@playwright/test";
+import {
+  DEV_GUILD_ID,
+  openUserMenu,
+  switchLanguage,
+  waitForIsland,
+} from "./helpers";
+
+test.describe("サーバー一覧", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/dashboard");
+  });
+
+  test("ログイン済みならトップからサーバー一覧へリダイレクトされる", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await expect(page).toHaveURL(/\/dashboard$/);
+  });
+
+  test("Bot 導入済みサーバーがチャンネル概要付きで表示される", async ({
+    page,
+  }) => {
+    await expect(
+      page.getByRole("heading", { level: 1, name: "サーバー一覧" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Bot 導入済み" }),
+    ).toBeVisible();
+
+    const card = page
+      .locator("div")
+      .filter({
+        has: page.getByRole("heading", { level: 3, name: "Dev Server 1" }),
+      })
+      .filter({ has: page.getByRole("link", { name: "設定を管理" }) })
+      .last();
+    await expect(card.getByText("導入済み", { exact: true })).toBeVisible();
+    await expect(card.getByText("4 チャンネル設定済み")).toBeVisible();
+    // Only enabled channels are previewed: "archives" is paused and must not appear.
+    for (const name of [
+      "#vspo-notifications",
+      "#schedule-en",
+      "#custom-picks",
+    ]) {
+      await expect(card.getByText(name, { exact: true })).toBeVisible();
+    }
+    await expect(card.getByText("#archives", { exact: true })).toHaveCount(0);
+    await expect(
+      card.getByRole("link", { name: "設定を管理" }),
+    ).toHaveAttribute("href", `/dashboard/${DEV_GUILD_ID}`);
+  });
+
+  test("管理者権限のないサーバーは一覧に表示されない", async ({ page }) => {
+    // The mock user owns Dev Server 1 only; Dev Server 2 is filtered out before rendering.
+    await expect(
+      page.getByRole("heading", { level: 3, name: "Dev Server 1" }),
+    ).toBeVisible();
+    await expect(page.getByText("Dev Server 2")).toHaveCount(0);
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Bot 未導入" }),
+    ).toHaveCount(0);
+  });
+
+  test("「設定を管理」からサーバー詳細へ遷移できる", async ({ page }) => {
+    await page.getByRole("link", { name: "設定を管理" }).click();
+    await expect(page).toHaveURL(new RegExp(`/dashboard/${DEV_GUILD_ID}$`));
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Dev Server 1" }),
+    ).toBeVisible();
+  });
+
+  test("サイドバーは現在地をハイライトし、折りたたみ状態を記憶する", async ({
+    page,
+  }) => {
+    await waitForIsland(page, "DesktopSidebarIsland");
+    const nav = page.getByRole("navigation", {
+      name: "サーバーナビゲーション",
+    });
+    await expect(
+      nav.getByRole("link", { name: "サーバー一覧" }),
+    ).toHaveAttribute("aria-current", "page");
+    await expect(nav.getByRole("link", { name: "お知らせ" })).toHaveAttribute(
+      "href",
+      "/dashboard/announcements",
+    );
+    const contact = nav.getByRole("link", { name: "お問い合わせ" });
+    await expect(contact).toHaveAttribute(
+      "href",
+      "https://example.com/contact",
+    );
+    await expect(contact).toHaveAttribute("target", "_blank");
+
+    const toggle = page.getByRole("button", { name: "サイドバーを折りたたむ" });
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(
+      page.locator("aside").getByRole("link", { name: "すべてのサーバー" }),
+    ).toBeVisible();
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await expect(
+      page.locator("aside").getByRole("link", { name: "すべてのサーバー" }),
+    ).toBeHidden();
+
+    await page.reload();
+    await waitForIsland(page, "DesktopSidebarIsland");
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  test("ユーザーメニューに言語・テーマ・ログアウトが表示され、外側クリックで閉じる", async ({
+    page,
+  }) => {
+    await openUserMenu(page);
+    const ja = page.getByRole("button", { name: "日本語" });
+    const en = page.getByRole("button", { name: "English" });
+    await expect(ja).toHaveAttribute("aria-pressed", "true");
+    await expect(en).toHaveAttribute("aria-pressed", "false");
+    await expect(
+      page.getByRole("button", { name: "テーマ", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "ログアウト" }),
+    ).toBeVisible();
+
+    await page.getByRole("heading", { level: 1, name: "サーバー一覧" }).click();
+    await expect(page.getByRole("button", { name: "ログアウト" })).toBeHidden();
+  });
+
+  test("ユーザーメニューの言語ボタンで英語表示に切り替わる", async ({
+    page,
+  }) => {
+    await openUserMenu(page);
+    await page.getByRole("button", { name: "English" }).click();
+
+    await expect(page.locator("html")).toHaveAttribute("lang", "en");
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Servers" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 2, name: "Bot Installed" }),
+    ).toBeVisible();
+  });
+
+  test("ヘッダーの言語メニューは元のページに戻る", async ({ page }) => {
+    await page.goto(`/dashboard/${DEV_GUILD_ID}`);
+    await switchLanguage(page, "English");
+    await expect(page).toHaveURL(new RegExp(`/dashboard/${DEV_GUILD_ID}$`));
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Dev Server 1" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Channel Settings", { exact: true }).first(),
+    ).toBeVisible();
+  });
+
+  test("ユーザーメニューのテーマボタンで dark モードに切り替わる", async ({
+    page,
+  }) => {
+    const html = page.locator("html");
+    await expect(html).not.toHaveClass(/dark/);
+    await openUserMenu(page);
+    await page.getByRole("button", { name: "テーマ", exact: true }).click();
+    await expect(html).toHaveClass(/dark/);
+  });
+
+  test("テーマは ClientRouter によるページ遷移後も維持される", async ({
+    page,
+  }) => {
+    await waitForIsland(page, "ThemeToggle");
+    await page.getByRole("button", { name: "テーマ切替" }).click();
+    await expect(page.locator("html")).toHaveClass(/dark/);
+
+    await page.getByRole("link", { name: "設定を管理" }).click();
+    await expect(page).toHaveURL(new RegExp(`/dashboard/${DEV_GUILD_ID}$`));
+    await expect(page.locator("html")).toHaveClass(/dark/);
+  });
+
+  test("モバイル幅ではハンバーガーメニューからナビゲーションを開閉できる", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.reload();
+
+    await expect(page.locator("aside")).toBeHidden();
+    const summary = page.locator("summary[aria-label='メニュー']");
+    await summary.click();
+
+    const nav = page.getByRole("navigation", {
+      name: "サーバーナビゲーション",
+    });
+    await expect(nav.getByRole("link", { name: "サーバー一覧" })).toBeVisible();
+    await expect(nav.getByRole("link", { name: "お知らせ" })).toBeVisible();
+
+    // Click well below the dropdown so the outside-click handler closes it.
+    await page.mouse.click(300, 780);
+    await expect(nav).toBeHidden();
+  });
+});

--- a/service/bot-dashboard/e2e/guild-channels.spec.ts
+++ b/service/bot-dashboard/e2e/guild-channels.spec.ts
@@ -1,0 +1,377 @@
+import { expect, test } from "@playwright/test";
+import {
+  channelCount,
+  channelRow,
+  channelTable,
+  DEV_GUILD_ID,
+  flash,
+  gotoGuild,
+  OTHER_GUILD_ID,
+  openAddModal,
+  openEditModal,
+} from "./helpers";
+
+test.describe("チャンネル設定ページの表示", () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoGuild(page);
+  });
+
+  test("パンくず・見出し・チャンネル数が表示される", async ({ page }) => {
+    const breadcrumb = page.getByRole("navigation", { name: "パンくずリスト" });
+    await expect(
+      breadcrumb.getByRole("link", { name: "すべてのサーバー" }),
+    ).toHaveAttribute("href", "/dashboard");
+    await expect(breadcrumb.getByText("Dev Server 1")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Dev Server 1" }),
+    ).toBeVisible();
+    await expect(channelCount(page)).toContainText("4");
+  });
+
+  test("登録済みチャンネルが言語・メンバー・ステータス付きで一覧される", async ({
+    page,
+  }) => {
+    await expect(channelTable(page).locator("tbody tr")).toHaveCount(4);
+
+    const notifications = channelRow(page, "vspo-notifications");
+    await expect(notifications).toContainText("100000000000000001");
+    await expect(notifications).toContainText("日本語");
+    await expect(notifications).toContainText("全メンバー");
+    await expect(notifications).toContainText("有効");
+
+    const scheduleEn = channelRow(page, "schedule-en");
+    await expect(scheduleEn).toContainText("英語");
+    await expect(scheduleEn).toContainText("VSPO EN");
+
+    const archives = channelRow(page, "archives");
+    await expect(archives).toContainText("VSPO JP");
+    await expect(archives).toContainText("停止中");
+
+    const custom = channelRow(page, "custom-picks");
+    for (const name of ["花芽すみれ", "一ノ瀬うるは", "Jira Jisaki"]) {
+      await expect(custom.getByRole("img", { name })).toBeVisible();
+    }
+  });
+
+  test("各行に編集・削除ボタンがある", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: "編集 #vspo-notifications" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "削除 #vspo-notifications" }),
+    ).toBeVisible();
+  });
+
+  test("サイドバーはチャンネル設定を現在地として表示する", async ({ page }) => {
+    const nav = page.getByRole("navigation", {
+      name: "サーバーナビゲーション",
+    });
+    await expect(
+      nav.getByRole("link", { name: "チャンネル設定" }),
+    ).toHaveAttribute("aria-current", "page");
+    await expect(nav.getByRole("link", { name: "お知らせ" })).toHaveAttribute(
+      "href",
+      `/dashboard/${DEV_GUILD_ID}/announcements`,
+    );
+    await expect(
+      page.locator("aside").getByRole("heading", { name: "Dev Server 1" }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("チャンネル未設定のサーバー", () => {
+  test("空状態と、追加候補が無いことが表示される", async ({ page }) => {
+    await gotoGuild(page, OTHER_GUILD_ID);
+    await expect(channelCount(page)).toContainText("0");
+    await expect(
+      page.getByText("設定済みのチャンネルがありません。"),
+    ).toBeVisible();
+
+    const dialog = await openAddModal(page);
+    await expect(dialog.getByText("チャンネルが見つかりません")).toBeVisible();
+  });
+});
+
+test.describe("チャンネル追加モーダル", () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoGuild(page);
+  });
+
+  test("未登録チャンネルは選択でき、登録済みは登録済みとして表示される", async ({
+    page,
+  }) => {
+    const dialog = await openAddModal(page);
+    const list = dialog.getByRole("listbox", { name: "チャンネルを追加" });
+    await expect(list.getByRole("option", { name: /general/ })).toBeVisible();
+    await expect(list.getByRole("option", { name: /random/ })).toBeVisible();
+    await expect(list.getByRole("option")).toHaveCount(2);
+    await expect(list.getByText("登録済み", { exact: true })).toHaveCount(4);
+    await expect(
+      list.getByText("vspo-notifications", { exact: true }),
+    ).toBeVisible();
+  });
+
+  test("検索でチャンネルを絞り込める", async ({ page }) => {
+    const dialog = await openAddModal(page);
+    const search = dialog.getByRole("searchbox", {
+      name: "チャンネル名で検索",
+    });
+    await search.fill("ran");
+    await expect(dialog.getByRole("option", { name: /random/ })).toBeVisible();
+    await expect(dialog.getByRole("option", { name: /general/ })).toHaveCount(
+      0,
+    );
+
+    await search.fill("zzz");
+    await expect(dialog.getByText("チャンネルが見つかりません")).toBeVisible();
+  });
+
+  test("キャンセルで閉じる", async ({ page }) => {
+    const dialog = await openAddModal(page);
+    await dialog.getByRole("button", { name: "キャンセル" }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test("閉じるボタンで閉じる", async ({ page }) => {
+    const dialog = await openAddModal(page);
+    await dialog.getByRole("button", { name: "閉じる" }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test("Escape キーで閉じる", async ({ page }) => {
+    const dialog = await openAddModal(page);
+    await dialog.getByRole("searchbox", { name: "チャンネル名で検索" }).focus();
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+  });
+
+  test("背景クリックで閉じる", async ({ page }) => {
+    const dialog = await openAddModal(page);
+    await dialog.click({ position: { x: 4, y: 4 } });
+    await expect(dialog).toBeHidden();
+  });
+});
+
+// These tests mutate the dev-mock store, which lives in the dev server process.
+// They run serially and each one restores the seed state it changed.
+test.describe
+  .serial("チャンネル設定の変更", () => {
+    test("チャンネルを追加すると一覧に表示され、再読み込み後も残る", async ({
+      page,
+    }) => {
+      await gotoGuild(page);
+      const dialog = await openAddModal(page);
+      await dialog.getByRole("option", { name: /general/ }).click();
+
+      await expect(dialog).toBeHidden();
+      await expect(flash(page)).toContainText("チャンネルを追加しました。");
+      const row = channelRow(page, "general");
+      await expect(row).toContainText("デフォルト");
+      await expect(row).toContainText("全メンバー");
+      await expect(row).toContainText("有効");
+
+      await gotoGuild(page);
+      await expect(channelCount(page)).toContainText("5");
+      await expect(channelRow(page, "general")).toBeVisible();
+    });
+
+    test("追加したチャンネルは追加モーダルで登録済みになる", async ({
+      page,
+    }) => {
+      await gotoGuild(page);
+      const dialog = await openAddModal(page);
+      await expect(dialog.getByRole("option", { name: /general/ })).toHaveCount(
+        0,
+      );
+      await expect(dialog.getByRole("option")).toHaveCount(1);
+    });
+
+    test("削除ダイアログはキャンセルできる", async ({ page }) => {
+      await gotoGuild(page);
+      await page.getByRole("button", { name: "削除 #general" }).click();
+      const dialog = page.getByRole("dialog", {
+        name: "#general を削除しますか？",
+      });
+      await expect(dialog).toContainText("この操作は取り消せません");
+      await dialog.getByRole("button", { name: "キャンセル" }).click();
+      await expect(dialog).toBeHidden();
+      await expect(channelRow(page, "general")).toBeVisible();
+    });
+
+    test("チャンネルを削除すると一覧から消え、再読み込み後も残らない", async ({
+      page,
+    }) => {
+      await gotoGuild(page);
+      await page.getByRole("button", { name: "削除 #general" }).click();
+      const dialog = page.getByRole("dialog", {
+        name: "#general を削除しますか？",
+      });
+      await dialog.getByRole("button", { name: "削除する" }).click();
+
+      await expect(dialog).toBeHidden();
+      await expect(flash(page)).toContainText("チャンネル設定を削除しました。");
+      await expect(channelRow(page, "general")).toHaveCount(0);
+
+      await gotoGuild(page);
+      await expect(channelCount(page)).toContainText("4");
+      await expect(channelRow(page, "general")).toHaveCount(0);
+    });
+
+    test("言語を変更すると変更プレビューが出て、保存で一覧に反映される", async ({
+      page,
+    }) => {
+      await gotoGuild(page);
+      const dialog = await openEditModal(page, "vspo-notifications");
+      const language = dialog.getByRole("combobox", { name: "言語" });
+      await expect(language).toHaveValue("ja");
+      await expect(dialog.getByText("変更プレビュー")).toHaveCount(0);
+
+      await language.selectOption("en");
+      const preview = dialog.getByText("変更プレビュー").locator("..");
+      await expect(preview).toContainText("言語");
+      await expect(preview).toContainText("日本語");
+      await expect(preview).toContainText("英語");
+
+      await dialog.getByRole("button", { name: "保存" }).click();
+      await expect(dialog).toBeHidden();
+      await expect(flash(page)).toContainText("チャンネル設定を更新しました。");
+      await expect(channelRow(page, "vspo-notifications")).toContainText(
+        "英語",
+      );
+
+      await gotoGuild(page);
+      await expect(channelRow(page, "vspo-notifications")).toContainText(
+        "英語",
+      );
+    });
+
+    test("言語を日本語に戻せる", async ({ page }) => {
+      await gotoGuild(page);
+      const dialog = await openEditModal(page, "vspo-notifications");
+      await dialog.getByRole("combobox", { name: "言語" }).selectOption("ja");
+      await dialog.getByRole("button", { name: "保存" }).click();
+      await expect(flash(page)).toContainText("チャンネル設定を更新しました。");
+      await expect(channelRow(page, "vspo-notifications")).toContainText(
+        "日本語",
+      );
+    });
+
+    test("デフォルトに戻すと言語とメンバータイプが初期化される", async ({
+      page,
+    }) => {
+      await gotoGuild(page);
+      const dialog = await openEditModal(page, "archives");
+      await dialog.getByRole("button", { name: "デフォルトに戻す" }).click();
+
+      await expect(dialog).toBeHidden();
+      await expect(flash(page)).toContainText(
+        "チャンネル設定をデフォルトに戻しました。",
+      );
+      const row = channelRow(page, "archives");
+      await expect(row).toContainText("デフォルト");
+      await expect(row).toContainText("全メンバー");
+
+      await gotoGuild(page);
+      await expect(channelRow(page, "archives")).toContainText("デフォルト");
+    });
+
+    test("メンバータイプと言語を同時に変更すると両方がプレビューされ保存される", async ({
+      page,
+    }) => {
+      await gotoGuild(page);
+      const dialog = await openEditModal(page, "archives");
+      await dialog.getByRole("radio", { name: "VSPO JP" }).check();
+      await dialog.getByRole("combobox", { name: "言語" }).selectOption("ja");
+
+      const preview = dialog.getByText("変更プレビュー").locator("..");
+      await expect(preview).toContainText("メンバー");
+      await expect(preview).toContainText("VSPO JP");
+      await expect(preview).toContainText("日本語");
+
+      await dialog.getByRole("button", { name: "保存" }).click();
+      await expect(flash(page)).toContainText("チャンネル設定を更新しました。");
+      const row = channelRow(page, "archives");
+      await expect(row).toContainText("日本語");
+      await expect(row).toContainText("VSPO JP");
+    });
+  });
+
+test.describe("チャンネル設定モーダル（カスタムメンバー）", () => {
+  test.beforeEach(async ({ page }) => {
+    await gotoGuild(page);
+  });
+
+  test("選択中のメンバーが件数・チップ・チェック状態で表示される", async ({
+    page,
+  }) => {
+    const dialog = await openEditModal(page, "custom-picks");
+    await expect(dialog.getByRole("radio", { name: "カスタム" })).toBeChecked();
+    await expect(dialog.getByText("3 名選択中")).toBeVisible();
+    for (const name of ["花芽すみれ", "一ノ瀬うるは", "Jira Jisaki"]) {
+      await expect(dialog.getByRole("checkbox", { name })).toBeChecked();
+      await expect(
+        dialog.getByRole("button", { name: `Remove ${name}` }),
+      ).toBeVisible();
+    }
+    await expect(
+      dialog.getByRole("checkbox", { name: "小雀とと" }),
+    ).not.toBeChecked();
+  });
+
+  test("チップの × で選択を外すと差分がプレビューされる", async ({ page }) => {
+    const dialog = await openEditModal(page, "custom-picks");
+    await dialog.getByRole("button", { name: "Remove 花芽すみれ" }).click();
+
+    await expect(dialog.getByText("2 名選択中")).toBeVisible();
+    const preview = dialog.getByText("変更プレビュー").locator("..");
+    await expect(preview).toContainText("カスタムメンバー");
+    await expect(preview).toContainText("-花芽すみれ");
+  });
+
+  test("メンバー検索で絞り込める", async ({ page }) => {
+    const dialog = await openEditModal(page, "custom-picks");
+    await dialog
+      .getByRole("searchbox", { name: "メンバーを検索" })
+      .fill("Jira");
+    await expect(
+      dialog.getByRole("checkbox", { name: "Jira Jisaki" }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByRole("checkbox", { name: "花芽すみれ" }),
+    ).toHaveCount(0);
+  });
+
+  test("グループの全選択 / 全解除ができる", async ({ page }) => {
+    const dialog = await openEditModal(page, "custom-picks");
+    const enGroup = dialog
+      .getByRole("heading", { name: "EN メンバー" })
+      .locator("..");
+    await enGroup.getByRole("button", { name: "全選択" }).click();
+    await expect(dialog.getByText("7 名選択中")).toBeVisible();
+
+    await enGroup.getByRole("button", { name: "全解除" }).click();
+    await expect(dialog.getByText("2 名選択中")).toBeVisible();
+  });
+
+  test("カスタムでメンバーが 0 名のときは保存できない", async ({ page }) => {
+    const dialog = await openEditModal(page, "vspo-notifications");
+    await dialog.getByRole("radio", { name: "カスタム" }).check();
+    const save = dialog.getByRole("button", { name: "保存" });
+    await expect(save).toBeDisabled();
+
+    await dialog.getByRole("checkbox", { name: "花芽すみれ" }).check();
+    await expect(dialog.getByText("1 名選択中")).toBeVisible();
+    await expect(save).toBeEnabled();
+  });
+
+  test("キャンセルすると変更は破棄される", async ({ page }) => {
+    const dialog = await openEditModal(page, "custom-picks");
+    await dialog.getByRole("button", { name: "Remove 花芽すみれ" }).click();
+    await dialog.getByRole("button", { name: "キャンセル" }).click();
+
+    await expect(dialog).toBeHidden();
+    await expect(
+      channelRow(page, "custom-picks").getByRole("img", { name: "花芽すみれ" }),
+    ).toBeVisible();
+  });
+});

--- a/service/bot-dashboard/e2e/guild-channels.spec.ts
+++ b/service/bot-dashboard/e2e/guild-channels.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import {
   channelCount,
   channelRow,
@@ -152,149 +152,205 @@ test.describe("チャンネル追加モーダル", () => {
   });
 });
 
-// These tests mutate the dev-mock store, which lives in the dev server process.
-// They run serially and each one restores the seed state it changed.
-test.describe
-  .serial("チャンネル設定の変更", () => {
-    test("チャンネルを追加すると一覧に表示され、再読み込み後も残る", async ({
-      page,
-    }) => {
-      await gotoGuild(page);
-      const dialog = await openAddModal(page);
-      await dialog.getByRole("option", { name: /general/ }).click();
+// The dev-mock store is process-wide, so these tests run on one worker and each
+// test arranges the state it needs and restores the seed before it ends.
+const addChannel = async (page: Page, name: string): Promise<void> => {
+  await gotoGuild(page);
+  if ((await channelRow(page, name).count()) > 0) return;
+  const dialog = await openAddModal(page);
+  await dialog.getByRole("option", { name: new RegExp(name) }).click();
+  await expect(dialog).toBeHidden();
+  await expect(channelRow(page, name)).toBeVisible();
+};
 
-      await expect(dialog).toBeHidden();
-      await expect(flash(page)).toContainText("チャンネルを追加しました。");
-      const row = channelRow(page, "general");
-      await expect(row).toContainText("デフォルト");
-      await expect(row).toContainText("全メンバー");
-      await expect(row).toContainText("有効");
-
-      await gotoGuild(page);
-      await expect(channelCount(page)).toContainText("5");
-      await expect(channelRow(page, "general")).toBeVisible();
-    });
-
-    test("追加したチャンネルは追加モーダルで登録済みになる", async ({
-      page,
-    }) => {
-      await gotoGuild(page);
-      const dialog = await openAddModal(page);
-      await expect(dialog.getByRole("option", { name: /general/ })).toHaveCount(
-        0,
-      );
-      await expect(dialog.getByRole("option")).toHaveCount(1);
-    });
-
-    test("削除ダイアログはキャンセルできる", async ({ page }) => {
-      await gotoGuild(page);
-      await page.getByRole("button", { name: "削除 #general" }).click();
-      const dialog = page.getByRole("dialog", {
-        name: "#general を削除しますか？",
-      });
-      await expect(dialog).toContainText("この操作は取り消せません");
-      await dialog.getByRole("button", { name: "キャンセル" }).click();
-      await expect(dialog).toBeHidden();
-      await expect(channelRow(page, "general")).toBeVisible();
-    });
-
-    test("チャンネルを削除すると一覧から消え、再読み込み後も残らない", async ({
-      page,
-    }) => {
-      await gotoGuild(page);
-      await page.getByRole("button", { name: "削除 #general" }).click();
-      const dialog = page.getByRole("dialog", {
-        name: "#general を削除しますか？",
-      });
-      await dialog.getByRole("button", { name: "削除する" }).click();
-
-      await expect(dialog).toBeHidden();
-      await expect(flash(page)).toContainText("チャンネル設定を削除しました。");
-      await expect(channelRow(page, "general")).toHaveCount(0);
-
-      await gotoGuild(page);
-      await expect(channelCount(page)).toContainText("4");
-      await expect(channelRow(page, "general")).toHaveCount(0);
-    });
-
-    test("言語を変更すると変更プレビューが出て、保存で一覧に反映される", async ({
-      page,
-    }) => {
-      await gotoGuild(page);
-      const dialog = await openEditModal(page, "vspo-notifications");
-      const language = dialog.getByRole("combobox", { name: "言語" });
-      await expect(language).toHaveValue("ja");
-      await expect(dialog.getByText("変更プレビュー")).toHaveCount(0);
-
-      await language.selectOption("en");
-      const preview = dialog.getByText("変更プレビュー").locator("..");
-      await expect(preview).toContainText("言語");
-      await expect(preview).toContainText("日本語");
-      await expect(preview).toContainText("英語");
-
-      await dialog.getByRole("button", { name: "保存" }).click();
-      await expect(dialog).toBeHidden();
-      await expect(flash(page)).toContainText("チャンネル設定を更新しました。");
-      await expect(channelRow(page, "vspo-notifications")).toContainText(
-        "英語",
-      );
-
-      await gotoGuild(page);
-      await expect(channelRow(page, "vspo-notifications")).toContainText(
-        "英語",
-      );
-    });
-
-    test("言語を日本語に戻せる", async ({ page }) => {
-      await gotoGuild(page);
-      const dialog = await openEditModal(page, "vspo-notifications");
-      await dialog.getByRole("combobox", { name: "言語" }).selectOption("ja");
-      await dialog.getByRole("button", { name: "保存" }).click();
-      await expect(flash(page)).toContainText("チャンネル設定を更新しました。");
-      await expect(channelRow(page, "vspo-notifications")).toContainText(
-        "日本語",
-      );
-    });
-
-    test("デフォルトに戻すと言語とメンバータイプが初期化される", async ({
-      page,
-    }) => {
-      await gotoGuild(page);
-      const dialog = await openEditModal(page, "archives");
-      await dialog.getByRole("button", { name: "デフォルトに戻す" }).click();
-
-      await expect(dialog).toBeHidden();
-      await expect(flash(page)).toContainText(
-        "チャンネル設定をデフォルトに戻しました。",
-      );
-      const row = channelRow(page, "archives");
-      await expect(row).toContainText("デフォルト");
-      await expect(row).toContainText("全メンバー");
-
-      await gotoGuild(page);
-      await expect(channelRow(page, "archives")).toContainText("デフォルト");
-    });
-
-    test("メンバータイプと言語を同時に変更すると両方がプレビューされ保存される", async ({
-      page,
-    }) => {
-      await gotoGuild(page);
-      const dialog = await openEditModal(page, "archives");
-      await dialog.getByRole("radio", { name: "VSPO JP" }).check();
-      await dialog.getByRole("combobox", { name: "言語" }).selectOption("ja");
-
-      const preview = dialog.getByText("変更プレビュー").locator("..");
-      await expect(preview).toContainText("メンバー");
-      await expect(preview).toContainText("VSPO JP");
-      await expect(preview).toContainText("日本語");
-
-      await dialog.getByRole("button", { name: "保存" }).click();
-      await expect(flash(page)).toContainText("チャンネル設定を更新しました。");
-      const row = channelRow(page, "archives");
-      await expect(row).toContainText("日本語");
-      await expect(row).toContainText("VSPO JP");
-    });
+const deleteChannel = async (page: Page, name: string): Promise<void> => {
+  await gotoGuild(page);
+  if ((await channelRow(page, name).count()) === 0) return;
+  await page.getByRole("button", { name: `削除 #${name}` }).click();
+  const dialog = page.getByRole("dialog", {
+    name: `#${name} を削除しますか？`,
   });
+  await dialog.getByRole("button", { name: "削除する" }).click();
+  await expect(dialog).toBeHidden();
+  await expect(channelRow(page, name)).toHaveCount(0);
+};
+
+const saveLanguage = async (
+  page: Page,
+  name: string,
+  language: string,
+): Promise<void> => {
+  await gotoGuild(page);
+  const dialog = await openEditModal(page, name);
+  await dialog.getByRole("combobox", { name: "言語" }).selectOption(language);
+  await dialog.getByRole("button", { name: "保存" }).click();
+  await expect(dialog).toBeHidden();
+};
+
+const resetToDefault = async (page: Page, name: string): Promise<void> => {
+  await gotoGuild(page);
+  const dialog = await openEditModal(page, name);
+  await dialog.getByRole("button", { name: "デフォルトに戻す" }).click();
+  await expect(dialog).toBeHidden();
+};
+
+/** The seed configures `archives` as VSPO JP / 日本語. */
+const restoreArchivesSeed = async (page: Page): Promise<void> => {
+  await gotoGuild(page);
+  const dialog = await openEditModal(page, "archives");
+  await dialog.getByRole("radio", { name: "VSPO JP" }).check();
+  await dialog.getByRole("combobox", { name: "言語" }).selectOption("ja");
+  await dialog.getByRole("button", { name: "保存" }).click();
+  await expect(dialog).toBeHidden();
+};
+
+test.describe("チャンネル設定の変更", () => {
+  test("チャンネルを追加すると一覧に表示され、再読み込み後も残る", async ({
+    page,
+  }) => {
+    await gotoGuild(page);
+    const dialog = await openAddModal(page);
+    await dialog.getByRole("option", { name: /general/ }).click();
+
+    await expect(dialog).toBeHidden();
+    await expect(flash(page)).toContainText("チャンネルを追加しました。");
+    const row = channelRow(page, "general");
+    await expect(row).toContainText("デフォルト");
+    await expect(row).toContainText("全メンバー");
+    await expect(row).toContainText("有効");
+
+    await gotoGuild(page);
+    await expect(channelCount(page)).toContainText("5");
+    await expect(channelRow(page, "general")).toBeVisible();
+
+    await deleteChannel(page, "general");
+  });
+
+  test("追加したチャンネルは追加モーダルで登録済みになる", async ({ page }) => {
+    await addChannel(page, "general");
+
+    const dialog = await openAddModal(page);
+    await expect(dialog.getByRole("option", { name: /general/ })).toHaveCount(
+      0,
+    );
+    await expect(dialog.getByRole("option")).toHaveCount(1);
+    await page.keyboard.press("Escape");
+
+    await deleteChannel(page, "general");
+  });
+
+  test("削除ダイアログはキャンセルできる", async ({ page }) => {
+    await gotoGuild(page);
+    await page.getByRole("button", { name: "削除 #custom-picks" }).click();
+    const dialog = page.getByRole("dialog", {
+      name: "#custom-picks を削除しますか？",
+    });
+    await expect(dialog).toContainText("この操作は取り消せません");
+    await dialog.getByRole("button", { name: "キャンセル" }).click();
+    await expect(dialog).toBeHidden();
+    await expect(channelRow(page, "custom-picks")).toBeVisible();
+  });
+
+  test("チャンネルを削除すると一覧から消え、再読み込み後も残らない", async ({
+    page,
+  }) => {
+    await addChannel(page, "general");
+
+    await page.getByRole("button", { name: "削除 #general" }).click();
+    const dialog = page.getByRole("dialog", {
+      name: "#general を削除しますか？",
+    });
+    await dialog.getByRole("button", { name: "削除する" }).click();
+
+    await expect(dialog).toBeHidden();
+    await expect(flash(page)).toContainText("チャンネル設定を削除しました。");
+    await expect(channelRow(page, "general")).toHaveCount(0);
+
+    await gotoGuild(page);
+    await expect(channelCount(page)).toContainText("4");
+    await expect(channelRow(page, "general")).toHaveCount(0);
+  });
+
+  test("言語を変更すると変更プレビューが出て、保存で一覧に反映される", async ({
+    page,
+  }) => {
+    await gotoGuild(page);
+    const dialog = await openEditModal(page, "vspo-notifications");
+    const language = dialog.getByRole("combobox", { name: "言語" });
+    await expect(language).toHaveValue("ja");
+    await expect(dialog.getByText("変更プレビュー")).toHaveCount(0);
+
+    await language.selectOption("en");
+    const preview = dialog.getByText("変更プレビュー").locator("..");
+    await expect(preview).toContainText("言語");
+    await expect(preview).toContainText("日本語");
+    await expect(preview).toContainText("英語");
+
+    await dialog.getByRole("button", { name: "保存" }).click();
+    await expect(dialog).toBeHidden();
+    await expect(flash(page)).toContainText("チャンネル設定を更新しました。");
+    await expect(channelRow(page, "vspo-notifications")).toContainText("英語");
+
+    await gotoGuild(page);
+    await expect(channelRow(page, "vspo-notifications")).toContainText("英語");
+
+    await saveLanguage(page, "vspo-notifications", "ja");
+  });
+
+  test("言語を日本語に戻せる", async ({ page }) => {
+    await saveLanguage(page, "vspo-notifications", "en");
+
+    const dialog = await openEditModal(page, "vspo-notifications");
+    await dialog.getByRole("combobox", { name: "言語" }).selectOption("ja");
+    await dialog.getByRole("button", { name: "保存" }).click();
+    await expect(flash(page)).toContainText("チャンネル設定を更新しました。");
+    await expect(channelRow(page, "vspo-notifications")).toContainText(
+      "日本語",
+    );
+  });
+
+  test("デフォルトに戻すと言語とメンバータイプが初期化される", async ({
+    page,
+  }) => {
+    await gotoGuild(page);
+    const dialog = await openEditModal(page, "archives");
+    await dialog.getByRole("button", { name: "デフォルトに戻す" }).click();
+
+    await expect(dialog).toBeHidden();
+    await expect(flash(page)).toContainText(
+      "チャンネル設定をデフォルトに戻しました。",
+    );
+    const row = channelRow(page, "archives");
+    await expect(row).toContainText("デフォルト");
+    await expect(row).toContainText("全メンバー");
+
+    await gotoGuild(page);
+    await expect(channelRow(page, "archives")).toContainText("デフォルト");
+
+    await restoreArchivesSeed(page);
+  });
+
+  test("メンバータイプと言語を同時に変更すると両方がプレビューされ保存される", async ({
+    page,
+  }) => {
+    await resetToDefault(page, "archives");
+
+    const dialog = await openEditModal(page, "archives");
+    await dialog.getByRole("radio", { name: "VSPO JP" }).check();
+    await dialog.getByRole("combobox", { name: "言語" }).selectOption("ja");
+
+    const preview = dialog.getByText("変更プレビュー").locator("..");
+    await expect(preview).toContainText("メンバー");
+    await expect(preview).toContainText("VSPO JP");
+    await expect(preview).toContainText("日本語");
+
+    await dialog.getByRole("button", { name: "保存" }).click();
+    await expect(flash(page)).toContainText("チャンネル設定を更新しました。");
+    const row = channelRow(page, "archives");
+    await expect(row).toContainText("日本語");
+    await expect(row).toContainText("VSPO JP");
+  });
+});
 
 test.describe("チャンネル設定モーダル（カスタムメンバー）", () => {
   test.beforeEach(async ({ page }) => {

--- a/service/bot-dashboard/e2e/helpers.ts
+++ b/service/bot-dashboard/e2e/helpers.ts
@@ -1,0 +1,77 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+export const ORIGIN = "http://localhost:4341";
+
+/** Guild seeded with channels in the dev mock (`devMock.guildConfig`). */
+export const DEV_GUILD_ID = "111111111111111111";
+/** Guild the mock user administers but where the bot is not installed. */
+export const OTHER_GUILD_ID = "222222222222222222";
+
+/** Astro islands keep the `ssr` attribute until hydration finishes. */
+export const waitForIsland = async (
+  page: Page,
+  componentExport: string,
+): Promise<void> => {
+  const island = page
+    .locator(`astro-island[component-export="${componentExport}"]`)
+    .first();
+  await expect(island).toBeAttached();
+  await expect(island).not.toHaveAttribute("ssr");
+};
+
+export const gotoGuild = async (
+  page: Page,
+  guildId: string = DEV_GUILD_ID,
+): Promise<void> => {
+  await page.goto(`/dashboard/${guildId}`);
+  await waitForIsland(page, "GuildDashboardIsland");
+};
+
+export const channelTable = (page: Page): Locator =>
+  page.getByRole("table", { name: "チャンネル設定" });
+
+export const channelRow = (page: Page, channelName: string): Locator =>
+  channelTable(page)
+    .locator("tbody tr")
+    .filter({ has: page.getByText(channelName, { exact: true }) });
+
+export const channelCount = (page: Page): Locator =>
+  page.getByText("導入チャンネル数", { exact: true }).locator("..");
+
+export const flash = (page: Page): Locator => page.getByRole("status");
+
+export const openUserMenu = async (page: Page): Promise<void> => {
+  await waitForIsland(page, "UserMenuIsland");
+  await page.getByRole("button", { name: "Dev User" }).click();
+};
+
+/** Switch the UI language through the header globe menu. */
+export const switchLanguage = async (
+  page: Page,
+  language: "日本語" | "English",
+): Promise<void> => {
+  await waitForIsland(page, "LanguageSelectorIsland");
+  await page.getByRole("button", { name: /^(言語|Language)$/ }).click();
+  await page.getByRole("menuitem", { name: language }).click();
+  await expect(page.locator("html")).toHaveAttribute(
+    "lang",
+    language === "English" ? "en" : "ja",
+  );
+};
+
+export const openEditModal = async (
+  page: Page,
+  channelName: string,
+): Promise<Locator> => {
+  await page.getByRole("button", { name: `編集 #${channelName}` }).click();
+  const dialog = page.getByRole("dialog", { name: `#${channelName} の設定` });
+  await expect(dialog).toBeVisible();
+  return dialog;
+};
+
+export const openAddModal = async (page: Page): Promise<Locator> => {
+  await page.getByRole("button", { name: "チャンネルを追加" }).first().click();
+  const dialog = page.getByRole("dialog", { name: "チャンネルを追加" });
+  await expect(dialog).toBeVisible();
+  return dialog;
+};

--- a/service/bot-dashboard/e2e/landing.spec.ts
+++ b/service/bot-dashboard/e2e/landing.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test } from "@playwright/test";
+import { switchLanguage, waitForIsland } from "./helpers";
+
+// The mock user is always logged in, so `?preview` is the only way to see the landing page.
+test.describe("ランディングページ", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/?preview");
+  });
+
+  test("ヒーローに見出し・説明・CTA が表示される", async ({ page }) => {
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      "Discord",
+    );
+    await expect(
+      page.getByText(
+        "ぶいすぽっ!メンバーの配信予定をDiscordに自動で届けます。",
+        {
+          exact: false,
+        },
+      ),
+    ).toBeVisible();
+
+    const addBot = page
+      .getByRole("link", { name: "サーバーに追加する" })
+      .first();
+    await expect(addBot).toHaveAttribute(
+      "href",
+      /^https:\/\/discord\.com\/oauth2\/authorize\?client_id=e2e-bot-id&/,
+    );
+    await expect(addBot).toHaveAttribute("target", "_blank");
+
+    await expect(
+      page.getByRole("link", { name: "Discordで管理画面へログイン" }).first(),
+    ).toHaveAttribute("href", "/auth/discord");
+  });
+
+  test("Bot の統計（サーバー数・利用者数）が表示される", async ({ page }) => {
+    const stats = page.locator(".hero-stats");
+    await expect(stats.getByText("サーバー", { exact: true })).toBeVisible();
+    await expect(stats.getByText("総利用者数", { exact: true })).toBeVisible();
+    await expect(stats.locator(".stat-card")).toHaveCount(2);
+    await expect(stats).toContainText("42");
+    await expect(stats).toContainText("1,234");
+  });
+
+  test("導入手順と /setting コマンドの説明が表示される", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "かんたん3ステップ" }),
+    ).toBeVisible();
+    for (const step of [
+      "Bot をサーバーに追加",
+      "/setting で初期設定",
+      "配信予定が届く",
+    ]) {
+      await expect(page.getByRole("heading", { name: step })).toBeVisible();
+    }
+
+    await expect(
+      page.getByRole("heading", { name: "/setting コマンド" }),
+    ).toBeVisible();
+    for (const card of [
+      "Bot を追加",
+      "Bot を削除",
+      "言語設定",
+      "メンバー選択",
+    ]) {
+      await expect(page.getByRole("heading", { name: card })).toBeVisible();
+    }
+  });
+
+  test("機能カードを開くとダイアログが表示され、閉じるボタンで閉じる", async ({
+    page,
+  }) => {
+    const card = page.getByRole("button", { name: /まとめて管理/ });
+    await card.scrollIntoViewIfNeeded();
+    await waitForIsland(page, "FeatureShowcase");
+    await card.click();
+
+    const dialog = page.getByRole("dialog", { name: "まとめて管理" });
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByRole("img", { name: "まとめて管理" }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByText("複数サーバーの設定をひとつの画面で確認・変更"),
+    ).toBeVisible();
+
+    await dialog.getByRole("button", { name: "閉じる" }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test("機能ダイアログは背景クリックで閉じる", async ({ page }) => {
+    const card = page.getByRole("button", { name: /通知対象を選べる/ });
+    await card.scrollIntoViewIfNeeded();
+    await waitForIsland(page, "FeatureShowcase");
+    await card.click();
+
+    const dialog = page.getByRole("dialog", { name: "通知対象を選べる" });
+    await expect(dialog).toBeVisible();
+    await dialog.click({ position: { x: 4, y: 4 } });
+    await expect(dialog).toBeHidden();
+  });
+
+  test("フッターに外部リンクが表示される", async ({ page }) => {
+    const footer = page.getByRole("navigation", { name: "Footer" });
+    await expect(
+      footer.getByRole("link", { name: "配信予定を確認する" }),
+    ).toHaveAttribute("href", "https://www.vspo-schedule.com/schedule/all");
+    await expect(
+      footer.getByRole("link", { name: "利用規約" }),
+    ).toHaveAttribute("href", "https://www.vspo-schedule.com/terms");
+    await expect(
+      footer.getByRole("link", { name: "プライバシーポリシー" }),
+    ).toHaveAttribute("href", "https://www.vspo-schedule.com/privacy-policy");
+  });
+
+  test("認証エラーで戻ってきた場合はアラートが表示され、閉じられる", async ({
+    page,
+  }) => {
+    await page.goto("/?error=auth_failed");
+    const alert = page.getByRole("alert");
+    await expect(alert).toContainText("Discord 認証に失敗しました");
+    await expect(
+      alert.getByRole("link", { name: "Discordで管理画面へログイン" }),
+    ).toHaveAttribute("href", "/auth/discord");
+    // The inline script strips the error param so a refresh does not repeat the alert.
+    await expect(page).toHaveURL(/\/$/);
+
+    await alert.getByRole("button", { name: "閉じる" }).click();
+    await expect(alert).toBeHidden();
+  });
+
+  test("ヘッダーの言語メニューで英語表示に切り替わる", async ({ page }) => {
+    await switchLanguage(page, "English");
+    await expect(page.getByRole("heading", { level: 1 })).toContainText(
+      "VSPO stream",
+    );
+    await expect(
+      page
+        .getByRole("link", { name: "Log in to Dashboard with Discord" })
+        .first(),
+    ).toBeVisible();
+  });
+
+  test("テーマ切替で dark クラスがトグルされ、再読み込み後も維持される", async ({
+    page,
+  }) => {
+    const html = page.locator("html");
+    await expect(html).not.toHaveClass(/dark/);
+
+    await waitForIsland(page, "ThemeToggle");
+    await page.getByRole("button", { name: "テーマ切替" }).click();
+    await expect(html).toHaveClass(/dark/);
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("theme")))
+      .toBe("dark");
+
+    await page.reload();
+    await expect(html).toHaveClass(/dark/);
+
+    await waitForIsland(page, "ThemeToggle");
+    await page.getByRole("button", { name: "テーマ切替" }).click();
+    await expect(html).not.toHaveClass(/dark/);
+  });
+});

--- a/service/bot-dashboard/package.json
+++ b/service/bot-dashboard/package.json
@@ -13,7 +13,9 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "storybook": "storybook dev -p 6007",
-    "storybook:build": "storybook build"
+    "storybook:build": "storybook build",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.10",
@@ -31,6 +33,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
+    "@playwright/test": "^1.62.1",
     "@storybook/html-vite": "^10.5.7",
     "@tailwindcss/vite": "^4.3.3",
     "@testing-library/dom": "^10.4.1",

--- a/service/bot-dashboard/playwright.config.ts
+++ b/service/bot-dashboard/playwright.config.ts
@@ -1,0 +1,56 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 4341;
+const baseURL = `http://localhost:${PORT}`;
+
+// Discord login and the APP_WORKER RPC are the only external dependencies; both are
+// replaced by the dev mock (DEV_MOCK_AUTH) so the app itself runs unmodified.
+const webServerEnv = {
+  ...process.env,
+  DEV_MOCK_AUTH: "true",
+  DISCORD_CLIENT_ID: "e2e-client-id",
+  DISCORD_CLIENT_SECRET: "e2e-client-secret",
+  DISCORD_REDIRECT_URI: `${baseURL}/auth/callback`,
+  DISCORD_BOT_CLIENT_ID: "e2e-bot-id",
+  CONTACT_FORM_URL: "https://example.com/contact",
+  ASTRO_DEV_BACKGROUND: "0",
+  ASTRO_TELEMETRY_DISABLED: "1",
+} satisfies Record<string, string | undefined>;
+
+export default defineConfig({
+  testDir: "./e2e",
+  // The dev-mock channel store is process-wide state, so specs must not interleave.
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  forbidOnly: !!process.env.CI,
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["list"]],
+  use: {
+    baseURL,
+    locale: "ja-JP",
+    trace: "retain-on-failure",
+    navigationTimeout: 60_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+          ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
+          : {},
+      },
+    },
+  ],
+  webServer: {
+    command: `pnpm exec astro dev --config astro.config.e2e.ts --port ${PORT}`,
+    url: `${baseURL}/robots.txt`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    env: webServerEnv,
+  },
+});

--- a/service/bot-dashboard/playwright.config.ts
+++ b/service/bot-dashboard/playwright.config.ts
@@ -49,7 +49,8 @@ export default defineConfig({
   webServer: {
     command: `pnpm exec astro dev --config astro.config.e2e.ts --port ${PORT}`,
     url: `${baseURL}/robots.txt`,
-    reuseExistingServer: !process.env.CI,
+    // The dev-mock store lives in the server process, so reuse is opt-in to keep runs deterministic.
+    reuseExistingServer: process.env.PLAYWRIGHT_REUSE_SERVER === "1",
     timeout: 180_000,
     env: webServerEnv,
   },

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -4,6 +4,7 @@ import type { GuildBotConfigType } from "~/features/guild/domain/guild";
 import {
   devMock,
   devMockChannelStore,
+  isDevMockActive,
   isRpcUnavailable,
 } from "~/features/shared/dev-mock";
 import type { CreatorType } from "~/features/shared/domain/creator";
@@ -187,13 +188,22 @@ const VspoChannelApiRepository = {
       customMembers?: string[] | undefined;
     },
   ): Promise<Result<void, AppError>> => {
-    if (isRpcUnavailable(appWorker)) {
+    if (isDevMockActive()) {
       devMockChannelStore.update(guildId, channelId, {
         language: data.language,
         memberType: data.memberType,
         customMembers: data.memberType === "custom" ? data.customMembers : [],
       });
       return Ok(undefined);
+    }
+    if (isRpcUnavailable(appWorker)) {
+      return Err(
+        new AppError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "APP_WORKER is not available",
+          context: {},
+        }),
+      );
     }
 
     return adjustAndEnqueue(appWorker, {
@@ -277,9 +287,18 @@ const VspoChannelApiRepository = {
     guildId: string,
     channelId: string,
   ): Promise<Result<void, AppError>> => {
-    if (isRpcUnavailable(appWorker)) {
+    if (isDevMockActive()) {
       devMockChannelStore.add(guildId, channelId);
       return Ok(undefined);
+    }
+    if (isRpcUnavailable(appWorker)) {
+      return Err(
+        new AppError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "APP_WORKER is not available",
+          context: {},
+        }),
+      );
     }
 
     return adjustAndEnqueue(appWorker, {
@@ -332,9 +351,18 @@ const VspoChannelApiRepository = {
     guildId: string,
     channelId: string,
   ): Promise<Result<void, AppError>> => {
-    if (isRpcUnavailable(appWorker)) {
+    if (isDevMockActive()) {
       devMockChannelStore.remove(guildId, channelId);
       return Ok(undefined);
+    }
+    if (isRpcUnavailable(appWorker)) {
+      return Err(
+        new AppError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "APP_WORKER is not available",
+          context: {},
+        }),
+      );
     }
 
     return adjustAndEnqueue(appWorker, {

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -197,7 +197,8 @@ const VspoChannelApiRepository = {
       devMockChannelStore.update(guildId, channelId, {
         language: data.language,
         memberType: data.memberType,
-        customMembers: data.memberType === "custom" ? data.customMembers : [],
+        customMembers:
+          data.memberType === "custom" ? (data.customMembers ?? []) : [],
       });
       return Ok(undefined);
     }

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -142,8 +142,11 @@ const VspoChannelApiRepository = {
     appWorker: ApplicationService,
     guildId: string,
   ): Promise<Result<GuildBotConfigType, AppError>> => {
-    if (isRpcUnavailable(appWorker)) {
+    if (isDevMockActive()) {
       return Ok(devMockChannelStore.list(guildId));
+    }
+    if (isRpcUnavailable(appWorker)) {
+      return Ok(devMock.guildConfig(guildId));
     }
 
     const discord = appWorker.newDiscordUsecase();

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -133,7 +133,9 @@ const VspoChannelApiRepository = {
    * @param guildId - Discord guild ID
    * @returns GuildBotConfig with all registered channels marked as enabled
    * @precondition appWorker is a valid service binding with DiscordService RPC
-   * @postcondition On Ok, all channels in the result have enabled === true
+   * @postcondition On Ok from the RPC path, all channels in the result have
+   *   enabled === true. When the RPC is unavailable, the dev-mock config is
+   *   returned as stored, including channels with enabled === false.
    * @idempotent true
    */
   getGuildConfig: async (

--- a/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
+++ b/service/bot-dashboard/src/features/channel/repository/vspo-channel-api.ts
@@ -1,7 +1,11 @@
 import type { Result } from "@vspo-lab/error";
 import { AppError, Err, Ok } from "@vspo-lab/error";
 import type { GuildBotConfigType } from "~/features/guild/domain/guild";
-import { devMock, isRpcUnavailable } from "~/features/shared/dev-mock";
+import {
+  devMock,
+  devMockChannelStore,
+  isRpcUnavailable,
+} from "~/features/shared/dev-mock";
 import type { CreatorType } from "~/features/shared/domain/creator";
 import type { ApplicationService } from "~/types/api";
 import type { MemberTypeValue } from "../domain/member-type";
@@ -136,7 +140,7 @@ const VspoChannelApiRepository = {
     guildId: string,
   ): Promise<Result<GuildBotConfigType, AppError>> => {
     if (isRpcUnavailable(appWorker)) {
-      return Ok(devMock.guildConfig(guildId));
+      return Ok(devMockChannelStore.list(guildId));
     }
 
     const discord = appWorker.newDiscordUsecase();
@@ -184,13 +188,12 @@ const VspoChannelApiRepository = {
     },
   ): Promise<Result<void, AppError>> => {
     if (isRpcUnavailable(appWorker)) {
-      return Err(
-        new AppError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "APP_WORKER is not available",
-          context: {},
-        }),
-      );
+      devMockChannelStore.update(guildId, channelId, {
+        language: data.language,
+        memberType: data.memberType,
+        customMembers: data.memberType === "custom" ? data.customMembers : [],
+      });
+      return Ok(undefined);
     }
 
     return adjustAndEnqueue(appWorker, {
@@ -275,13 +278,8 @@ const VspoChannelApiRepository = {
     channelId: string,
   ): Promise<Result<void, AppError>> => {
     if (isRpcUnavailable(appWorker)) {
-      return Err(
-        new AppError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "APP_WORKER is not available",
-          context: {},
-        }),
-      );
+      devMockChannelStore.add(guildId, channelId);
+      return Ok(undefined);
     }
 
     return adjustAndEnqueue(appWorker, {
@@ -335,13 +333,8 @@ const VspoChannelApiRepository = {
     channelId: string,
   ): Promise<Result<void, AppError>> => {
     if (isRpcUnavailable(appWorker)) {
-      return Err(
-        new AppError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "APP_WORKER is not available",
-          context: {},
-        }),
-      );
+      devMockChannelStore.remove(guildId, channelId);
+      return Ok(undefined);
     }
 
     return adjustAndEnqueue(appWorker, {

--- a/service/bot-dashboard/src/features/shared/dev-mock.ts
+++ b/service/bot-dashboard/src/features/shared/dev-mock.ts
@@ -1,4 +1,5 @@
 import { DEV_MOCK_AUTH } from "astro:env/server";
+import type { ChannelConfigType } from "~/features/channel/domain/channel-config";
 import type { GuildBotConfigType } from "~/features/guild/domain/guild";
 import type { CreatorType } from "~/features/shared/domain/creator";
 import type { ApplicationService } from "~/types/api";
@@ -29,7 +30,7 @@ export const devMock = {
       guildId === DEV_GUILD_ID
         ? [
             {
-              channelId: "ch-001",
+              channelId: "100000000000000001",
               channelName: "vspo-notifications",
               enabled: true,
               language: "ja",
@@ -37,7 +38,7 @@ export const devMock = {
               customMembers: undefined,
             },
             {
-              channelId: "ch-002",
+              channelId: "100000000000000002",
               channelName: "schedule-en",
               enabled: true,
               language: "en",
@@ -45,7 +46,7 @@ export const devMock = {
               customMembers: undefined,
             },
             {
-              channelId: "ch-003",
+              channelId: "100000000000000003",
               channelName: "archives",
               enabled: false,
               language: "ja",
@@ -53,7 +54,7 @@ export const devMock = {
               customMembers: undefined,
             },
             {
-              channelId: "ch-004",
+              channelId: "100000000000000004",
               channelName: "custom-picks",
               enabled: true,
               language: "ja",
@@ -71,12 +72,12 @@ export const devMock = {
   guildChannels: (guildId: string): { id: string; name: string }[] =>
     guildId === DEV_GUILD_ID
       ? [
-          { id: "ch-001", name: "vspo-notifications" },
-          { id: "ch-002", name: "schedule-en" },
-          { id: "ch-003", name: "archives" },
-          { id: "ch-004", name: "custom-picks" },
-          { id: "ch-mock-1", name: "general" },
-          { id: "ch-mock-2", name: "random" },
+          { id: "100000000000000001", name: "vspo-notifications" },
+          { id: "100000000000000002", name: "schedule-en" },
+          { id: "100000000000000003", name: "archives" },
+          { id: "100000000000000004", name: "custom-picks" },
+          { id: "100000000000000005", name: "general" },
+          { id: "100000000000000006", name: "random" },
         ]
       : [],
 
@@ -185,4 +186,63 @@ export const devMock = {
       permissions: "0",
     },
   ],
+} as const;
+
+// Mutations must round-trip in dev-mock mode so the dashboard can be exercised end to end.
+const mockChannels = new Map<string, ChannelConfigType[]>();
+
+const channelsOf = (guildId: string): ChannelConfigType[] => {
+  const existing = mockChannels.get(guildId);
+  if (existing) return existing;
+  const seeded = devMock.guildConfig(guildId).channels;
+  mockChannels.set(guildId, seeded);
+  return seeded;
+};
+
+export const devMockChannelStore = {
+  list: (guildId: string): GuildBotConfigType => ({
+    guildId,
+    channels: channelsOf(guildId),
+  }),
+
+  add: (guildId: string, channelId: string): void => {
+    const channels = channelsOf(guildId);
+    if (channels.some((ch) => ch.channelId === channelId)) return;
+    const name =
+      devMock.guildChannels(guildId).find((ch) => ch.id === channelId)?.name ??
+      channelId;
+    mockChannels.set(guildId, [
+      ...channels,
+      {
+        channelId,
+        channelName: name,
+        enabled: true,
+        language: "default",
+        memberType: "all",
+      },
+    ]);
+  },
+
+  update: (
+    guildId: string,
+    channelId: string,
+    patch: Pick<
+      Partial<ChannelConfigType>,
+      "language" | "memberType" | "customMembers"
+    >,
+  ): void => {
+    mockChannels.set(
+      guildId,
+      channelsOf(guildId).map((ch) =>
+        ch.channelId === channelId ? { ...ch, ...patch } : ch,
+      ),
+    );
+  },
+
+  remove: (guildId: string, channelId: string): void => {
+    mockChannels.set(
+      guildId,
+      channelsOf(guildId).filter((ch) => ch.channelId !== channelId),
+    );
+  },
 } as const;

--- a/service/bot-dashboard/src/features/shared/dev-mock.ts
+++ b/service/bot-dashboard/src/features/shared/dev-mock.ts
@@ -20,6 +20,10 @@ export const isRpcUnavailable = (appWorker: ApplicationService): boolean => {
   return typeof appWorker.newDiscordUsecase !== "function";
 };
 
+/** Only the dev server with the mock enabled may write to the in-memory store. */
+export const isDevMockActive = (): boolean =>
+  import.meta.env.DEV && DEV_MOCK_AUTH !== false;
+
 const DEV_GUILD_ID = "111111111111111111";
 
 /** ローカル開発用のモックデータ。APP_WORKER が利用不可な場合に使用する。 */


### PR DESCRIPTION
## Current State
`service/bot-dashboard` has vitest unit and component tests only. Pages, the OAuth routes, middleware, Astro Actions and the API routes are not exercised by any automated test, and `docs/testing/e2e-testing.md` says "Not yet implemented".

## Problem
Framework upgrades (Astro 7 landed in #1142 with only a manual smoke test) and feature changes can break user-facing flows without CI noticing.

## Changes
- **Playwright suite (66 tests)** under `service/bot-dashboard/e2e/`, one file per screen or concern: `landing`, `auth`, `dashboard`, `guild-channels`, `announcements`, `api`. Covers the hero / stats / feature dialogs / footer / error alert, the OAuth flow at the HTTP level (authorize redirect with PKCE, callback state and code handling, replay), logout, server list, desktop sidebar and mobile menu, user menu, locale switching, theme persistence across ClientRouter navigation, channel table, add / edit / reset / delete with change preview and flash messages, custom member selection, announcements in both locales, the channels and change-locale API routes (CSRF and open-redirect guards), robots.txt, 404 and security headers.
- **Mock boundary**: the app runs under `astro dev` with `DEV_MOCK_AUTH=true`, the mock the repository already ships. It replaces the two external dependencies only: Discord OAuth and the `APP_WORKER` service binding (the worker lives in another repository). Everything in this repo runs for real.
- **Dev mock fix**: mutations returned "APP_WORKER is not available" and the mock channel ids failed the actions' snowflake validation, so add / edit / delete could never succeed in local dev either. The mock now keeps an in-memory channel store and uses snowflake ids.
- **CI**: new `e2e-bot-dashboard` job in `pr-check.yaml` (installs Chromium, runs the suite, uploads the HTML report on failure) and a row in the PR Check Summary.
- `playwright.config.ts`, `astro.config.e2e.ts` (dev toolbar off), `test:e2e` scripts, `.gitignore` / `biome.json` entries for Playwright output, and the docs page rewritten around what is implemented.

## Impact
- `service/bot-dashboard` only, plus CI and docs. No production code path changes: the dev mock is gated behind `import.meta.env.DEV`.
- Not covered on purpose: the guild-admin guard and token refresh in the middleware, which the mock middleware bypasses. Those stay unit-test territory.
- Local run: `pnpm --filter bot-dashboard test:e2e` (starts the dev server on port 4341 by itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8P78E9M9U45hZ7bfKwkye

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8P78E9M9U45hZ7bfKwkye)_